### PR TITLE
fix: add trust proxy for Render reverse proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ import createCategoryRouter from "./modules/category";
 
 const app = express();
 
+// Behind reverse proxy (Render, etc.) — needed for rate limiting & correct client IP
+app.set("trust proxy", 1);
+
 // --- Security middleware ---
 app.use(helmet());
 


### PR DESCRIPTION
Express rate-limit lanzaba ERR_ERL_UNEXPECTED_X_FORWARDED_FOR en Render porque trust proxy no estaba configurado. Agrega app.set(trust proxy, 1) en src/index.ts.