### PR TITLE
feat: token revocation and logout endpoint

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -42,4 +42,20 @@ export class AuthController {
       res.status(401).json({ message: "Refresh token inválido o expirado" });
     }
   };
+
+  logout = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { refreshToken } = req.body;
+      if (!refreshToken) {
+        res.status(400).json({ message: "refreshToken no proporcionado" });
+        return;
+      }
+
+      await this.service.logout(refreshToken);
+      res.status(200).json({ message: "Sesión cerrada correctamente" });
+    } catch (error) {
+      console.error("Error en logout:", error);
+      res.status(500).json({ message: "Error al cerrar sesión" });
+    }
+  };
 }

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -2,13 +2,15 @@ import { Router } from "express";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { UserRepository } from "@modules/user/user.repository";
+import { RevokedTokenRepository } from "./revokedToken.repository";
 import { validate } from "@shared/middlewares/validate.middleware";
 import { loginGoogleSchema, refreshTokenSchema } from "./auth.schemas";
 
 const createAuthRouter = (): Router => {
   const router = Router();
   const userRepository = new UserRepository();
-  const authService = new AuthService(userRepository);
+  const revokedTokenRepository = new RevokedTokenRepository();
+  const authService = new AuthService(userRepository, revokedTokenRepository);
   const controller = new AuthController(authService);
 
   router.post(
@@ -20,6 +22,11 @@ const createAuthRouter = (): Router => {
     "/refresh",
     validate(refreshTokenSchema),
     controller.refresh.bind(controller),
+  );
+  router.post(
+    "/logout",
+    validate(refreshTokenSchema),
+    controller.logout.bind(controller),
   );
 
   return router;

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -4,9 +4,13 @@ import { UserRepository } from "@modules/user/user.repository";
 import { User } from "@modules/user/user.model";
 import { AuthError } from "@shared/errors/custom.error";
 import { saveTokenToFirestore } from "@/config/gmailAuth";
+import { RevokedTokenRepository } from "./revokedToken.repository";
 
 export class AuthService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly revokedTokenRepository: RevokedTokenRepository,
+  ) {}
 
   async loginWithGoogle(
     idToken: string,
@@ -110,9 +114,16 @@ export class AuthService {
       const decoded = jwt.verify(refreshToken, refreshSecret) as {
         userId: string;
         type?: string;
+        exp?: number;
       };
       if (!decoded || decoded.type !== "refresh" || !decoded.userId) {
         throw new Error("Refresh token inválido");
+      }
+
+      // Verificar si el token fue revocado
+      const isRevoked = await this.revokedTokenRepository.isRevoked(refreshToken);
+      if (isRevoked) {
+        throw new Error("Refresh token revocado");
       }
 
       const user = await this.userRepository.findById(decoded.userId);
@@ -127,7 +138,6 @@ export class AuthService {
         } as jwt.SignOptions,
       );
 
-      // Opcional: rotar refresh token (aquí devolvemos uno nuevo)
       const newRefreshToken = jwt.sign(
         { userId: user.id, type: "refresh" },
         refreshSecret,
@@ -136,10 +146,36 @@ export class AuthService {
         } as jwt.SignOptions,
       );
 
+      // Revocar el refresh token anterior
+      const expiresAt = decoded.exp
+        ? new Date(decoded.exp * 1000)
+        : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      await this.revokedTokenRepository.revoke(refreshToken, expiresAt);
+
       return { accessToken, refreshToken: newRefreshToken };
     } catch (error) {
       console.error("Error refreshing token:", error);
       throw error;
+    }
+  }
+
+  async logout(refreshToken: string): Promise<void> {
+    try {
+      const refreshSecret =
+        process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET!;
+      const decoded = jwt.verify(refreshToken, refreshSecret) as {
+        exp?: number;
+      };
+      const expiresAt = decoded.exp
+        ? new Date(decoded.exp * 1000)
+        : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      await this.revokedTokenRepository.revoke(refreshToken, expiresAt);
+    } catch {
+      // Si el token ya expiró o es inválido, no importa — igualmente revocamos el hash
+      await this.revokedTokenRepository.revoke(
+        refreshToken,
+        new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      );
     }
   }
 }

--- a/src/modules/auth/revokedToken.repository.ts
+++ b/src/modules/auth/revokedToken.repository.ts
@@ -1,0 +1,28 @@
+import { db } from "@/config/firebase";
+import crypto from "crypto";
+
+const REVOKED_TOKENS_COLLECTION = "revokedTokens";
+
+function hashToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export class RevokedTokenRepository {
+  async revoke(token: string, expiresAt: Date): Promise<void> {
+    const tokenHash = hashToken(token);
+    await db.collection(REVOKED_TOKENS_COLLECTION).doc(tokenHash).set({
+      tokenHash,
+      revokedAt: new Date().toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    });
+  }
+
+  async isRevoked(token: string): Promise<boolean> {
+    const tokenHash = hashToken(token);
+    const doc = await db
+      .collection(REVOKED_TOKENS_COLLECTION)
+      .doc(tokenHash)
+      .get();
+    return doc.exists;
+  }
+}


### PR DESCRIPTION
## Problema

No existia forma de invalidar refresh tokens. Si alguien robaba un token, tenia 30 dias de acceso sin poder ser revocado. Tampoco habia endpoint de logout real.

## Solucion

### Nuevo: RevokedTokenRepository
- Coleccion revokedTokens en Firestore
- Almacena hash SHA-256 del token (nunca el token raw)
- Guarda fecha de revocacion y expiracion (para limpieza futura)

### Cambios en refresh flow
- Antes de emitir nuevos tokens, verifica que el refresh token no este revocado
- Al rotar tokens, revoca automaticamente el token anterior

### Nuevo endpoint: POST /api/logout
- Recibe refreshToken en el body
- Revoca el token en Firestore
- Retorna 200 con confirmacion

## Nota para frontend
La app debe llamar POST /api/logout con el refreshToken al cerrar sesion.