### PR TITLE
refactor: Quota due_date/payment_date a camelCase

### DIFF
--- a/src/modules/billingPeriod/billingPeriod.service.ts
+++ b/src/modules/billingPeriod/billingPeriod.service.ts
@@ -68,7 +68,7 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
   }
 
   /**
-   * Marca como pagadas todas las cuotas pendientes cuyo due_date
+   * Marca como pagadas todas las cuotas pendientes cuyo dueDate
    * cae dentro del rango del período de facturación.
    */
   async payBillingPeriod(
@@ -103,7 +103,7 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
 
       const pendingInRange = quotas.filter((q) => {
         if (q.status !== "pending") return false;
-        const dueTime = new Date(q.due_date).getTime();
+        const dueTime = new Date(q.dueDate).getTime();
         return dueTime >= startDate && dueTime <= endDate;
       });
 
@@ -114,7 +114,7 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
           .doc(quota.id);
         await quotaRef.update({
           status: "paid",
-          payment_date: paymentDate,
+          paymentDate: paymentDate,
           updatedAt: paymentDate,
         });
         paidCount++;

--- a/src/modules/quota/quota.model.ts
+++ b/src/modules/quota/quota.model.ts
@@ -4,10 +4,10 @@ export class Quota implements IBaseEntity {
   id!: string; // Fireorm requiere un ID explícito
   transactionId!: string; // ID de la transacción asociada
   amount!: number; // Monto de la cuota
-  due_date!: Date; // Fecha de vencimiento de la cuota
+  dueDate!: Date; // Fecha de vencimiento de la cuota
   status!: "pending" | "paid"; // Estado de la cuota
   currency!: string; // Moneda de la cuota
-  payment_date?: Date | null; // Fecha de pago de la cuota (opcional)
+  paymentDate?: Date | null; // Fecha de pago de la cuota (opcional)
   createdAt!: Date;
   updatedAt!: Date;
   deletedAt!: Date | null;

--- a/src/modules/quota/quota.schemas.ts
+++ b/src/modules/quota/quota.schemas.ts
@@ -4,10 +4,10 @@ export const createQuotaSchema = z
   .object({
     transactionId: z.string().min(1),
     amount: z.number().min(0),
-    due_date: z.string().or(z.coerce.date()),
+    dueDate: z.string().or(z.coerce.date()),
     status: z.enum(["pending", "paid"]),
     currency: z.string().min(1),
-    payment_date: z.string().or(z.coerce.date()).nullable().optional(),
+    paymentDate: z.string().or(z.coerce.date()).nullable().optional(),
   })
   .strict();
 

--- a/src/modules/quota/quota.service.ts
+++ b/src/modules/quota/quota.service.ts
@@ -36,7 +36,7 @@ export class QuotaService extends BaseService<Quota> {
   /**
    * Divide una transacción en N cuotas mensuales.
    * Elimina las cuotas existentes y crea N nuevas con montos divididos
-   * y due_dates mensuales a partir de la fecha de la transacción.
+   * y dueDates mensuales a partir de la fecha de la transacción.
    */
   async splitTransactionIntoQuotas(
     creditCardId: string,
@@ -70,7 +70,7 @@ export class QuotaService extends BaseService<Quota> {
     for (let i = 0; i < numberOfQuotas; i++) {
       const dueDate = new Date(transactionDate);
       if (numberOfQuotas === 1) {
-        // Pago único: due_date = fecha de la transacción
+        // Pago único: dueDate = fecha de la transacción
       } else {
         // Cuotas: primera cuota al mes siguiente, y así sucesivamente
         dueDate.setMonth(dueDate.getMonth() + i + 1);
@@ -86,7 +86,7 @@ export class QuotaService extends BaseService<Quota> {
         id: this.transactionRepository.repository.doc().id,
         transactionId,
         amount,
-        due_date: dueDate,
+        dueDate: dueDate,
         status: "pending",
         currency: transaction.currency,
         createdAt: new Date(),

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -177,7 +177,7 @@ export class StatsService {
             pendingCount++;
 
             // Find which billing period this quota belongs to
-            const dueTime = new Date(q.due_date as unknown as string).getTime();
+            const dueTime = new Date(q.dueDate as unknown as string).getTime();
             const periodMonth = allBillingPeriods.find((p) => {
               return (
                 dueTime >= new Date(p.startDate).getTime() &&
@@ -186,7 +186,7 @@ export class StatsService {
             })?.month;
 
             // Compute calendar month key for this quota
-            const dueDate = new Date(q.due_date as unknown as string);
+            const dueDate = new Date(q.dueDate as unknown as string);
             const calKey = `${dueDate.getFullYear()}-${String(dueDate.getMonth() + 1).padStart(2, "0")}`;
 
             const bucketKey = periodMonth ?? calKey;
@@ -205,7 +205,7 @@ export class StatsService {
               bucket.CLP += q.amount;
               totalCLP += q.amount;
             }
-            // Keep sortKey as the earliest due_date in this bucket
+            // Keep sortKey as the earliest dueDate in this bucket
             if (dueTime < bucket.sortKey) bucket.sortKey = dueTime;
 
             // Next payment = quotas in current billing period or current calendar month

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -55,7 +55,14 @@ export class TransactionRepository extends FirestoreRepository<Transaction> {
     const snapshot = await quotasCollection
       .where("deletedAt", "==", null)
       .get();
-    return snapshot.docs.map((doc) => doc.data() as Quota);
+    return snapshot.docs.map((doc) => {
+      const raw = doc.data() as unknown as Record<string, unknown>;
+      return {
+        ...raw,
+        dueDate: raw.dueDate ?? raw.due_date,
+        paymentDate: raw.paymentDate ?? raw.payment_date,
+      } as Quota;
+    });
   }
 
   // Eliminar todas las cuotas de una transacción (hard delete)

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -477,7 +477,7 @@ export class TransactionService extends BaseService<Transaction> {
     for (let i = 1; i <= data.totalInstallments; i++) {
       const isPaid = i <= data.paidInstallments;
 
-      // Calcular due_date: cuotas van mes a mes
+      // Calcular dueDate: cuotas van mes a mes
       // Cuota paidInstallments cae en lastPaidMonth
       // Offset from lastPaidMonth: i - paidInstallments
       const monthOffset = i - data.paidInstallments;
@@ -487,10 +487,10 @@ export class TransactionService extends BaseService<Transaction> {
         id: this.repository.repository.doc().id,
         transactionId,
         amount: data.quotaAmount,
-        due_date: dueDate,
+        dueDate: dueDate,
         status: isPaid ? "paid" : "pending",
         currency: data.currency,
-        payment_date: isPaid ? dueDate : null,
+        paymentDate: isPaid ? dueDate : null,
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
@@ -583,10 +583,10 @@ export class TransactionService extends BaseService<Transaction> {
         id: this.repository.repository.doc().id,
         transactionId,
         amount: data.quotaAmount,
-        due_date: dueDate,
+        dueDate: dueDate,
         status: isPaid ? "paid" : "pending",
         currency: data.currency,
-        payment_date: isPaid ? dueDate : null,
+        paymentDate: isPaid ? dueDate : null,
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
@@ -644,7 +644,7 @@ export class TransactionService extends BaseService<Transaction> {
           id: this.repository.repository.doc().id,
           transactionId: transaction.id,
           amount: transaction.amount,
-          due_date: transaction.transactionDate,
+          dueDate: transaction.transactionDate,
           status: "pending",
           currency: transaction.currency,
           createdAt: new Date(),
@@ -712,9 +712,9 @@ export class TransactionService extends BaseService<Transaction> {
       for (const billingPeriod of formattedBillingPeriods) {
         periodSumMap[billingPeriod.periodKey] = {};
         const quotasInPeriod = allQuotas.filter((quota) => {
-          if (!quota.due_date) return false;
+          if (!quota.dueDate) return false;
           const quotaDate = new Date(
-            convertUtcToChileTime(quota.due_date, "yyyy-MM-dd HH:mm:ss"),
+            convertUtcToChileTime(quota.dueDate, "yyyy-MM-dd HH:mm:ss"),
           );
           return (
             quotaDate >= billingPeriod.startDate &&


### PR DESCRIPTION
Renombra los campos snake_case del modelo Quota a camelCase para consistencia con el resto de entidades.

Cambios:
- due_date -> dueDate
- payment_date -> paymentDate

Archivos backend (7):
- quota.model.ts: campos renombrados
- quota.schemas.ts: Zod schemas actualizados
- quota.service.ts: referencias actualizadas
- transaction.repository.ts: getQuotas() con backward-compat mapping para datos existentes en Firestore (raw.dueDate ?? raw.due_date)
- transaction.service.ts: 3 bloques de creacion de cuotas actualizados
- billingPeriod.service.ts: filtro y update de cuotas actualizados
- stats.service.ts: computacion de deuda actualizada

Retrocompatibilidad: datos existentes en Firestore con due_date/payment_date siguen funcionando gracias al mapping en getQuotas().

IMPORTANTE: deployar junto con el PR del frontend (misma interfaz de API).