### PR TITLE
refactor: extract EmailImportService from TransactionService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,19 +218,19 @@ Before delivering code:
 
 Existing issues to resolve progressively:
 
-1. `TransactionService` too large (~740 lines) — extract to specialized services
+1. ~~`TransactionService` too large (~740 lines)~~ — EmailImportService extracted (466 lines remaining, consider further extraction of ManualTransaction logic)
 2. Repository boundary violations — repos accessing other collections
-3. `stats` module incomplete — empty repository, unused interfaces
-4. `UserService` constructor bug — ignores injected repository
-5. `MerchantPattern` doesn't follow pattern — no IBaseEntity
-6. snake_case in `Quota` model — `due_date`, `payment_date`
-7. Excessive console.log with emojis
-8. `errorHandler` debug leftovers
+3. ~~`stats` module incomplete~~ — empty repository deleted (PR #9)
+4. ~~`UserService` constructor bug~~ — fixed (PR #8)
+5. ~~`MerchantPattern` doesn't follow pattern~~ — now implements IBaseEntity (PR #9)
+6. ~~snake_case in `Quota` model~~ — migrated to camelCase (PR #10)
+7. ~~Excessive console.log with emojis~~ — cleaned up (PR #8)
+8. ~~`errorHandler` debug leftovers~~ — hardened (PR #8)
 9. `@Collection` decorator unused
-10. No `req.body` validation — future: add Zod
+10. ~~No `req.body` validation~~ — Zod schemas added (PR #5)
 11. No tests
 12. Environment variables without validation
-13. Currency inconsistency — "Dolar" vs "CLP"
+13. ~~Currency inconsistency — "Dolar" vs "CLP"~~ — normalized to USD (PR #11)
 
 ---
 

--- a/src/modules/transaction/emailImport.service.ts
+++ b/src/modules/transaction/emailImport.service.ts
@@ -1,0 +1,235 @@
+import { Auth, gmail_v1, google } from "googleapis";
+import { getTokenFromFirestore } from "@config/gmailAuth";
+import * as cheerio from "cheerio";
+import { chunkArray } from "@/shared/utils/array.utils";
+import { parseFirebaseDate } from "@/shared/utils/date.utils";
+
+import { TransactionRepository } from "./transaction.repository";
+import { Transaction } from "./transaction.model";
+import { CategoryService } from "@/modules/category/category.service";
+
+/**
+ * Handles Gmail integration and bank-email parsing.
+ *
+ * Extracted from TransactionService to isolate external-API and HTML-parsing
+ * concerns. This service is stateless; all dependencies are passed explicitly.
+ */
+export class EmailImportService {
+  /**
+   * Fetches new bank-notification emails from the user's Gmail inbox,
+   * parses transaction data from the HTML body, and persists new records.
+   *
+   * @returns The number of newly imported transactions.
+   */
+  async fetchBankEmails(
+    userId: string,
+    repository: TransactionRepository,
+  ): Promise<{ importedCount: number }> {
+    const tokenData = await getTokenFromFirestore(userId);
+
+    if (!tokenData) {
+      throw new Error(
+        "No se encontró un token de Gmail. Conéctate con Gmail nuevamente.",
+      );
+    }
+
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const auth: Auth.OAuth2Client = new google.auth.OAuth2(
+      clientId,
+      clientSecret,
+    );
+    auth.setCredentials({
+      access_token: tokenData.accessToken,
+      refresh_token: tokenData.refreshToken,
+      expiry_date: tokenData.expiryDate,
+    });
+
+    // Refresh expired token
+    if (new Date().getTime() > tokenData.expiryDate) {
+      if (!tokenData.refreshToken) {
+        throw new Error(
+          "El token de Gmail ha expirado y no hay refresh_token. Conéctate nuevamente.",
+        );
+      }
+      try {
+        const { credentials } = await auth.refreshAccessToken();
+        auth.setCredentials(credentials);
+
+        const { saveTokenToFirestore } = await import("@config/gmailAuth");
+        await saveTokenToFirestore(userId, {
+          access_token: credentials.access_token,
+          refresh_token: credentials.refresh_token || tokenData.refreshToken,
+          expiry_date: credentials.expiry_date,
+        });
+      } catch (refreshError) {
+        console.error("Error renovando token de Gmail:", refreshError);
+        throw new Error(
+          "No se pudo renovar el token de Gmail. Conéctate nuevamente.",
+        );
+      }
+    }
+
+    const gmail = google.gmail({ version: "v1", auth });
+
+    const today = new Date();
+    const startOfMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+    const formattedDate = `${startOfMonth.getFullYear()}/${(
+      startOfMonth.getMonth() + 1
+    )
+      .toString()
+      .padStart(2, "0")}/${startOfMonth.getDate().toString().padStart(2, "0")}`;
+
+    const query = `from:enviodigital@bancochile.cl subject:compra tarjeta crédito after:${formattedDate}`;
+    const res = await gmail.users.messages.list({ userId: "me", q: query });
+
+    if (!res.data.messages) {
+      return { importedCount: 0 };
+    }
+
+    const messageIds = res.data.messages.map((message) => message.id!);
+    const existingIds = await repository.getExistingTransactionIds(messageIds);
+    const newMessageIds = messageIds.filter((id) => !existingIds.includes(id));
+
+    if (newMessageIds.length === 0) {
+      return { importedCount: 0 };
+    }
+
+    const chunks = chunkArray(newMessageIds, 100);
+    let batchData: Transaction[] = [];
+    let totalImported = 0;
+
+    // Pre-load merchant→category map once for all emails
+    const categoryService = new CategoryService();
+    let merchantMap: Map<string, { categoryId: string; categoryName: string }>;
+    try {
+      merchantMap = await categoryService.buildMerchantCategoryMap();
+    } catch (err) {
+      console.error("Error pre-cargando merchant map:", err);
+      merchantMap = new Map();
+    }
+
+    for (const chunk of chunks) {
+      await Promise.all(
+        chunk.map(async (messageId) => {
+          const email = await gmail.users.messages.get({
+            userId: "me",
+            id: messageId,
+          });
+          let encodedMessage = email.data.payload?.body?.data;
+
+          if (email.data.payload) {
+            encodedMessage = this.findHtmlOrPlainText(email.data.payload);
+          }
+
+          if (encodedMessage) {
+            const content = Buffer.from(encodedMessage, "base64").toString(
+              "utf8",
+            );
+            const {
+              amount,
+              currency,
+              cardLastDigits,
+              merchant,
+              transactionDate,
+            } = this.extractTransactionDataFromHtml(content);
+
+            if (amount && cardLastDigits && merchant && transactionDate) {
+              const transactionData: Transaction = {
+                id: messageId,
+                amount,
+                currency,
+                cardType: "Tarjeta de Crédito",
+                cardLastDigits,
+                merchant,
+                categoryId: undefined,
+                transactionDate,
+                bank: "Banco de Chile",
+                email: "enviodigital@bancochile.cl",
+                creditCardId: "",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                deletedAt: null,
+              };
+
+              const match = CategoryService.matchMerchantInMap(
+                merchant,
+                merchantMap,
+              );
+              if (match) {
+                transactionData.categoryId = match.categoryId;
+              }
+
+              batchData.push(transactionData);
+            }
+          }
+        }),
+      );
+
+      if (batchData.length > 0) {
+        totalImported += batchData.length;
+        await repository.saveBatch(batchData);
+        batchData = [];
+      }
+    }
+
+    return { importedCount: totalImported };
+  }
+
+  /**
+   * Recursively searches a MIME message tree for the HTML (or plain-text) body.
+   */
+  private findHtmlOrPlainText(
+    part: gmail_v1.Schema$MessagePart,
+  ): string | null | undefined {
+    if (part.mimeType === "text/html" || part.mimeType === "text/plain") {
+      return part.body?.data;
+    } else if (
+      (part.mimeType === "multipart/alternative" ||
+        part.mimeType === "multipart/mixed") &&
+      part.parts
+    ) {
+      for (const subPart of part.parts) {
+        const result = this.findHtmlOrPlainText(subPart);
+        if (result) return result;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Parses the HTML content of a Banco de Chile purchase notification
+   * and extracts structured transaction data.
+   */
+  private extractTransactionDataFromHtml(htmlContent: string) {
+    const $ = cheerio.load(htmlContent);
+
+    const textContent = $('td:contains("compra por")').text();
+
+    // Detect currency and amount
+    const amountMatch = textContent.match(
+      /(?:US\$|CLP\$|\$)(\d{1,64}(?:[.,]\d{3})*(?:[.,]\d{2})?)/,
+    );
+    const currency = textContent.includes("US$") ? "USD" : "CLP";
+
+    let amount = null;
+    if (amountMatch) {
+      const amountString = amountMatch[1].replace(/\./g, "").replace(",", ".");
+      amount = parseFloat(amountString);
+    }
+
+    const lastDigitsMatch = textContent.match(
+      /Tarjeta de Crédito \*\*\*\*(\d{4})/,
+    );
+    const merchantMatch = textContent.match(/en (.+?) el \d{2}\/\d{2}\/\d{4}/);
+    const dateMatch = textContent.match(/\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}/);
+
+    const cardLastDigits = lastDigitsMatch ? lastDigitsMatch[1] : null;
+    const merchant = merchantMatch
+      ? merchantMatch[1].replace(/\s+/g, " ").trim()
+      : null;
+    const transactionDate = dateMatch ? parseFirebaseDate(dateMatch[0]) : null;
+
+    return { amount, currency, cardLastDigits, merchant, transactionDate };
+  }
+}

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -1,15 +1,7 @@
-import { Auth, gmail_v1, google } from "googleapis";
-import { getTokenFromFirestore } from "../../config/gmailAuth";
-import * as cheerio from "cheerio";
-import { chunkArray } from "@/shared/utils/array.utils";
-import {
-  convertUtcToChileTime,
-  parseFirebaseDate,
-} from "@/shared/utils/date.utils";
+import { convertUtcToChileTime } from "@/shared/utils/date.utils";
 
 import { TransactionRepository } from "./transaction.repository";
 import { Transaction } from "./transaction.model";
-import { CategoryService } from "@/modules/category/category.service";
 import { BaseService } from "@/shared/classes/base.service";
 import { Quota } from "@/modules/quota/quota.model";
 import { BillingPeriodRepository } from "../billingPeriod/billingPeriod.repository";
@@ -18,11 +10,13 @@ import {
   CacheKeys,
   CacheTTL,
 } from "@/shared/services/cache.service";
+import { EmailImportService } from "./emailImport.service";
 
 export class TransactionService extends BaseService<Transaction> {
   // Cambiar el tipo del repository para acceder a los métodos específicos
   protected repository: TransactionRepository;
   private billingPeriodRepository: BillingPeriodRepository;
+  private emailImportService: EmailImportService;
 
   constructor(
     repository: TransactionRepository,
@@ -32,169 +26,11 @@ export class TransactionService extends BaseService<Transaction> {
     // Guardar la referencia al repository tipado
     this.repository = repository;
     this.billingPeriodRepository = billingPeriodRepository;
+    this.emailImportService = new EmailImportService();
   }
 
-  // Otros métodos específicos del servicio
   async fetchBankEmails(userId: string): Promise<{ importedCount: number }> {
-    // Verificar si ya hay un token guardado en Firestore
-    const tokenData = await getTokenFromFirestore(userId);
-
-    if (!tokenData) {
-      throw new Error(
-        "No se encontró un token de Gmail. Conéctate con Gmail nuevamente.",
-      );
-    }
-
-    // Crear cliente OAuth con el token guardado
-    const clientId = process.env.GOOGLE_CLIENT_ID;
-    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
-    const auth: Auth.OAuth2Client = new google.auth.OAuth2(
-      clientId,
-      clientSecret,
-    );
-    auth.setCredentials({
-      access_token: tokenData.accessToken,
-      refresh_token: tokenData.refreshToken,
-      expiry_date: tokenData.expiryDate,
-    });
-
-    // Si el token expiró, intentar renovar con refresh_token
-    if (new Date().getTime() > tokenData.expiryDate) {
-      if (!tokenData.refreshToken) {
-        throw new Error(
-          "El token de Gmail ha expirado y no hay refresh_token. Conéctate nuevamente.",
-        );
-      }
-      try {
-        const { credentials } = await auth.refreshAccessToken();
-        auth.setCredentials(credentials);
-
-        const { saveTokenToFirestore } = await import("../../config/gmailAuth");
-        await saveTokenToFirestore(userId, {
-          access_token: credentials.access_token,
-          refresh_token: credentials.refresh_token || tokenData.refreshToken,
-          expiry_date: credentials.expiry_date,
-        });
-      } catch (refreshError) {
-        console.error("Error renovando token de Gmail:", refreshError);
-        throw new Error(
-          "No se pudo renovar el token de Gmail. Conéctate nuevamente.",
-        );
-      }
-    }
-
-    const gmail = google.gmail({ version: "v1", auth });
-
-    const today = new Date();
-    const startOfMonth = new Date(today.getFullYear(), today.getMonth() - 1, 1);
-    const formattedDate = `${startOfMonth.getFullYear()}/${(
-      startOfMonth.getMonth() + 1
-    )
-      .toString()
-      .padStart(2, "0")}/${startOfMonth.getDate().toString().padStart(2, "0")}`;
-
-    const query = `from:enviodigital@bancochile.cl subject:compra tarjeta crédito after:${formattedDate}`;
-    const res = await gmail.users.messages.list({ userId: "me", q: query });
-
-    if (res.data.messages) {
-      const messageIds = res.data.messages.map((message) => message.id!);
-      const existingIds =
-        await this.repository.getExistingTransactionIds(messageIds);
-      const newMessageIds = messageIds.filter(
-        (id) => !existingIds.includes(id),
-      );
-
-      if (newMessageIds.length === 0) {
-        return { importedCount: 0 };
-      }
-      const chunks = chunkArray(newMessageIds, 100);
-      let batchData: Transaction[] = [];
-      let totalImported = 0;
-
-      // Pre-cargar el mapa de merchants UNA sola vez para todos los correos.
-      // Costo fijo: N_categories reads. Sin esto sería N_emails × N_categories reads.
-      const categoryService = new CategoryService();
-      let merchantMap: Map<
-        string,
-        { categoryId: string; categoryName: string }
-      >;
-      try {
-        merchantMap = await categoryService.buildMerchantCategoryMap();
-      } catch (err) {
-        console.error("Error pre-cargando merchant map:", err);
-        merchantMap = new Map();
-      }
-
-      for (const chunk of chunks) {
-        await Promise.all(
-          chunk.map(async (messageId) => {
-            const email = await gmail.users.messages.get({
-              userId: "me",
-              id: messageId,
-            });
-            let encodedMessage = email.data.payload?.body?.data;
-
-            if (email.data.payload) {
-              encodedMessage = this.findHtmlOrPlainText(email.data.payload);
-            }
-
-            if (encodedMessage) {
-              const content = Buffer.from(encodedMessage, "base64").toString(
-                "utf8",
-              );
-              const {
-                amount,
-                currency,
-                cardLastDigits,
-                merchant,
-                transactionDate,
-              } = this.extractTransactionDataFromHtml(content);
-
-              if (amount && cardLastDigits && merchant && transactionDate) {
-                const transactionData: Transaction = {
-                  id: messageId,
-                  amount,
-                  currency,
-                  cardType: "Tarjeta de Crédito",
-                  cardLastDigits,
-                  merchant,
-                  // categoryId will be set if we find an automatic match
-                  categoryId: undefined,
-                  transactionDate,
-                  bank: "Banco de Chile",
-                  email: "enviodigital@bancochile.cl",
-                  createdAt: new Date(),
-                  updatedAt: new Date(),
-                  deletedAt: null,
-                  creditCardId: "",
-                };
-
-                // Lookup en el mapa pre-cargado — sin reads adicionales
-                const match = CategoryService.matchMerchantInMap(
-                  merchant,
-                  merchantMap,
-                );
-                if (match) {
-                  transactionData.categoryId = match.categoryId;
-                }
-
-                batchData.push(transactionData);
-              }
-            }
-          }),
-        );
-
-        if (batchData.length > 0) {
-          totalImported += batchData.length;
-          await this.repository.saveBatch(batchData);
-          batchData = [];
-        }
-      }
-      return { importedCount: totalImported };
-    } else {
-      console.warn("No se encontraron correos de transacciones para este mes.");
-    }
-    return { importedCount: 0 };
+    return this.emailImportService.fetchBankEmails(userId, this.repository);
   }
 
   /**
@@ -367,66 +203,6 @@ export class TransactionService extends BaseService<Transaction> {
       orphanedTransactions,
       suggestedPeriod,
     };
-  }
-
-  // Función recursiva para buscar contenido HTML o texto plano en partes anidadas
-  private findHtmlOrPlainText(
-    part: gmail_v1.Schema$MessagePart,
-  ): string | null | undefined {
-    // Busca contenido HTML o texto plano directamente
-    if (part.mimeType === "text/html" || part.mimeType === "text/plain") {
-      return part.body?.data;
-    }
-    // Si la parte es multipart/alternative o multipart/mixed, explora sus subpartes
-    else if (
-      (part.mimeType === "multipart/alternative" ||
-        part.mimeType === "multipart/mixed") &&
-      part.parts
-    ) {
-      for (const subPart of part.parts) {
-        const result = this.findHtmlOrPlainText(subPart);
-        if (result) return result;
-      }
-    }
-    return undefined;
-  }
-
-  // Función para analizar contenido HTML y extraer la información
-  private extractTransactionDataFromHtml(htmlContent: string) {
-    const $ = cheerio.load(htmlContent);
-
-    // Extraer el texto del elemento que contiene el mensaje principal
-    const textContent = $('td:contains("compra por")').text();
-
-    // Detectar la moneda y el monto
-    const amountMatch = textContent.match(
-      /(?:US\$|CLP\$|\$)(\d{1,64}(?:[.,]\d{3})*(?:[.,]\d{2})?)/,
-    );
-    const currency = textContent.includes("US$") ? "USD" : "CLP";
-
-    // Formatear el monto extraído para asegurar que siempre sea un número válido
-    let amount = null;
-    if (amountMatch) {
-      const amountString = amountMatch[1].replace(/\./g, "").replace(",", ".");
-      amount = parseFloat(amountString);
-    }
-
-    // Extraer otros datos
-    const lastDigitsMatch = textContent.match(
-      /Tarjeta de Crédito \*\*\*\*(\d{4})/,
-    );
-    const merchantMatch = textContent.match(/en (.+?) el \d{2}\/\d{2}\/\d{4}/);
-    const dateMatch = textContent.match(/\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}/);
-
-    // Formatear otros datos extraídos
-    const cardLastDigits = lastDigitsMatch ? lastDigitsMatch[1] : null;
-    const merchant = merchantMatch
-      ? merchantMatch[1].replace(/\s+/g, " ").trim()
-      : null;
-    // Convertir transactionDate a un objeto Date si se extrajo correctamente
-    const transactionDate = dateMatch ? parseFirebaseDate(dateMatch[0]) : null;
-
-    return { amount, currency, cardLastDigits, merchant, transactionDate };
   }
 
   /**


### PR DESCRIPTION
Extracts Gmail integration and HTML parsing logic from TransactionService into a dedicated EmailImportService. TransactionService reduced from ~740 to 466 lines. Zero API changes - controller, routes, and all endpoints remain identical. The new EmailImportService contains: fetchBankEmails, findHtmlOrPlainText, and extractTransactionDataFromHtml.