### PR TITLE
refactor: extract ManualTransactionService + move getMonthlyQuotaSum to stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ Before delivering code:
 
 Existing issues to resolve progressively:
 
-1. ~~`TransactionService` too large (~740 lines)~~ — EmailImportService extracted (466 lines remaining, consider further extraction of ManualTransaction logic)
+1. ~~`TransactionService` too large (~740 lines)~~ — EmailImportService, ManualTransactionService extracted, getMonthlyQuotaSum moved to StatsService (~280 lines remaining)
 2. Repository boundary violations — repos accessing other collections
 3. ~~`stats` module incomplete~~ — empty repository deleted (PR #9)
 4. ~~`UserService` constructor bug~~ — fixed (PR #8)

--- a/src/modules/stats/stats.controller.ts
+++ b/src/modules/stats/stats.controller.ts
@@ -23,6 +23,23 @@ export class StatsController {
     }
   };
 
+  // Obtener sumatoria de cuotas por período de facturación
+  getMonthlyQuotaSum = async (req: Request, res: Response): Promise<void> => {
+    const { creditCardId } = req.params;
+
+    try {
+      const monthlyQuotaSum =
+        await this.service.getMonthlyQuotaSum(creditCardId);
+      res.status(200).json(monthlyQuotaSum);
+    } catch (error) {
+      console.error("Error al obtener la sumatoria de cuotas por mes:", error);
+      res.status(500).json({
+        message: "Error al obtener la sumatoria de cuotas por mes",
+        error: error instanceof Error ? error.message : "Error desconocido",
+      });
+    }
+  };
+
   // Obtener resumen de deuda global (todas las tarjetas)
   static getDebtSummary = async (
     req: Request,

--- a/src/modules/stats/stats.routes.ts
+++ b/src/modules/stats/stats.routes.ts
@@ -61,6 +61,13 @@ const createStatsRouter = (): Router => {
     },
   );
 
+  router.get(
+    "/creditCards/:creditCardId/stats/monthly-quota-sum",
+    (req: Request, res: Response) => {
+      return res.locals.statsController.getMonthlyQuotaSum(req, res);
+    },
+  );
+
   return router;
 };
 

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -42,6 +42,93 @@ export class StatsService {
     private billingPeriodRepository: BillingPeriodRepository,
   ) {}
 
+  /**
+   * Obtiene la sumatoria de cuotas organizadas por períodos de facturación.
+   * Costo L3: 1 (billingPeriods) + 1 (transactions) + N_transactions (getQuotas) reads.
+   * Resultado cacheado en L1 memoria con TTL MEDIUM (2 min).
+   */
+  async getMonthlyQuotaSum(
+    creditCardId: string,
+  ): Promise<{ period: string; currency: string; totalAmount: number }[]> {
+    const cacheKey = CacheKeys.monthlyQuotaSum(creditCardId);
+    const cached =
+      CacheService.get<
+        { period: string; currency: string; totalAmount: number }[]
+      >(cacheKey);
+    if (cached !== null) return cached;
+
+    try {
+      const [billingPeriods, transactions] = await Promise.all([
+        this.billingPeriodRepository.findAll(),
+        this.transactionRepository.findAll(),
+      ]);
+
+      if (!billingPeriods.length || !transactions.length) return [];
+
+      const formattedBillingPeriods = billingPeriods.map((period) => ({
+        periodKey: `${convertUtcToChileTime(
+          period.startDate,
+          "yyyy-MM-dd",
+        )} - ${convertUtcToChileTime(period.endDate, "yyyy-MM-dd")}`,
+        startDate: new Date(
+          convertUtcToChileTime(period.startDate, "yyyy-MM-dd HH:mm:ss"),
+        ),
+        endDate: new Date(
+          convertUtcToChileTime(period.endDate, "yyyy-MM-dd HH:mm:ss"),
+        ),
+      }));
+
+      const allQuotas = (
+        await Promise.all(
+          transactions.map((tx) =>
+            this.transactionRepository.getQuotas(creditCardId, tx.id),
+          ),
+        )
+      ).flat();
+
+      const periodSumMap: { [key: string]: { [currency: string]: number } } =
+        {};
+
+      for (const billingPeriod of formattedBillingPeriods) {
+        periodSumMap[billingPeriod.periodKey] = {};
+        const quotasInPeriod = allQuotas.filter((quota) => {
+          if (!quota.dueDate) return false;
+          const quotaDate = new Date(
+            convertUtcToChileTime(quota.dueDate, "yyyy-MM-dd HH:mm:ss"),
+          );
+          return (
+            quotaDate >= billingPeriod.startDate &&
+            quotaDate <= billingPeriod.endDate
+          );
+        });
+        for (const quota of quotasInPeriod) {
+          periodSumMap[billingPeriod.periodKey][quota.currency] =
+            (periodSumMap[billingPeriod.periodKey][quota.currency] ?? 0) +
+            quota.amount;
+        }
+      }
+
+      const result = Object.entries(periodSumMap).flatMap(
+        ([period, currencyMap]) =>
+          Object.entries(currencyMap).map(([currency, totalAmount]) => ({
+            period,
+            currency,
+            totalAmount,
+          })),
+      );
+
+      CacheService.set(cacheKey, result, CacheTTL.MEDIUM);
+
+      return result;
+    } catch (error) {
+      console.error(
+        "Error al obtener la sumatoria de las cuotas por período de facturación:",
+        error,
+      );
+      throw error;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Firestore materialized view document references
   // Path: users/{userId}/summaries/debtSummary

--- a/src/modules/transaction/manualTransaction.service.ts
+++ b/src/modules/transaction/manualTransaction.service.ts
@@ -1,0 +1,177 @@
+import { TransactionRepository } from "./transaction.repository";
+import { Transaction } from "./transaction.model";
+import { Quota } from "@/modules/quota/quota.model";
+
+/**
+ * Handles CRUD operations for manual (user-entered) transactions and their
+ * quota generation. Extracted from TransactionService to isolate manual-debt
+ * logic from email-import and reporting concerns.
+ */
+export class ManualTransactionService {
+  constructor(private readonly repository: TransactionRepository) {}
+
+  /**
+   * Creates a manual transaction with all its quotas (paid and pending).
+   */
+  async create(
+    creditCardId: string,
+    data: {
+      merchant: string;
+      purchaseDate: string;
+      quotaAmount: number;
+      totalInstallments: number;
+      paidInstallments: number;
+      lastPaidMonth: string; // "2026-01"
+      currency: string;
+      categoryId?: string;
+    },
+  ): Promise<{ transaction: Transaction; quotasCreated: number }> {
+    const transactionId = this.repository.repository.doc().id;
+    const transaction: Transaction = {
+      id: transactionId,
+      amount: data.quotaAmount,
+      currency: data.currency,
+      cardType: "",
+      cardLastDigits: "",
+      merchant: data.merchant,
+      categoryId: data.categoryId,
+      transactionDate: new Date(data.purchaseDate),
+      bank: "manual",
+      email: "",
+      creditCardId,
+      source: "manual",
+      totalInstallments: data.totalInstallments,
+      paidInstallments: data.paidInstallments,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    };
+
+    await this.repository.create(transaction);
+
+    // lastPaidMonth is "2026-01" => quota #paidInstallments was paid in that month
+    // Pending quotas start from the following month
+    const [lastYear, lastMonthNum] = data.lastPaidMonth.split("-").map(Number);
+
+    for (let i = 1; i <= data.totalInstallments; i++) {
+      const isPaid = i <= data.paidInstallments;
+      const monthOffset = i - data.paidInstallments;
+      const dueDate = new Date(lastYear, lastMonthNum - 1 + monthOffset, 15);
+
+      const quota: Quota = {
+        id: this.repository.repository.doc().id,
+        transactionId,
+        amount: data.quotaAmount,
+        dueDate: dueDate,
+        status: isPaid ? "paid" : "pending",
+        currency: data.currency,
+        paymentDate: isPaid ? dueDate : null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      await this.repository.addQuota(creditCardId, transactionId, quota);
+    }
+
+    return { transaction, quotasCreated: data.totalInstallments };
+  }
+
+  /**
+   * Deletes a manual transaction and all its quotas (hard delete).
+   */
+  async delete(
+    creditCardId: string,
+    transactionId: string,
+  ): Promise<{ deletedQuotas: number }> {
+    const transaction = await this.repository.findById(transactionId);
+    if (!transaction) {
+      throw new Error("Transacción no encontrada");
+    }
+    if (transaction.source !== "manual") {
+      throw new Error("Solo se pueden eliminar transacciones manuales");
+    }
+
+    const deletedQuotas = await this.repository.deleteAllQuotas(
+      creditCardId,
+      transactionId,
+    );
+    await this.repository.delete(transactionId);
+
+    return { deletedQuotas };
+  }
+
+  /**
+   * Updates a manual transaction: modifies data and recreates all quotas.
+   */
+  async update(
+    creditCardId: string,
+    transactionId: string,
+    data: {
+      merchant: string;
+      purchaseDate: string;
+      quotaAmount: number;
+      totalInstallments: number;
+      paidInstallments: number;
+      lastPaidMonth: string;
+      currency: string;
+      categoryId?: string;
+    },
+  ): Promise<{ transaction: Transaction; quotasCreated: number }> {
+    const existing = await this.repository.findById(transactionId);
+    if (!existing) {
+      throw new Error("Transacción no encontrada");
+    }
+    if (existing.source !== "manual") {
+      throw new Error("Solo se pueden editar transacciones manuales");
+    }
+
+    await this.repository.update(transactionId, {
+      merchant: data.merchant,
+      amount: data.quotaAmount,
+      ...(data.categoryId ? { categoryId: data.categoryId } : {}),
+      currency: data.currency,
+      transactionDate: new Date(data.purchaseDate),
+      totalInstallments: data.totalInstallments,
+      paidInstallments: data.paidInstallments,
+      updatedAt: new Date(),
+    } as Partial<Transaction>);
+
+    // Delete all existing quotas and recreate them
+    await this.repository.deleteAllQuotas(creditCardId, transactionId);
+
+    const [lastYear, lastMonthNum] = data.lastPaidMonth.split("-").map(Number);
+
+    for (let i = 1; i <= data.totalInstallments; i++) {
+      const isPaid = i <= data.paidInstallments;
+      const monthOffset = i - data.paidInstallments;
+      const dueDate = new Date(lastYear, lastMonthNum - 1 + monthOffset, 15);
+
+      const quota: Quota = {
+        id: this.repository.repository.doc().id,
+        transactionId,
+        amount: data.quotaAmount,
+        dueDate: dueDate,
+        status: isPaid ? "paid" : "pending",
+        currency: data.currency,
+        paymentDate: isPaid ? dueDate : null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      await this.repository.addQuota(creditCardId, transactionId, quota);
+    }
+
+    const updated = await this.repository.findById(transactionId);
+    return { transaction: updated!, quotasCreated: data.totalInstallments };
+  }
+
+  /**
+   * Lists only manual transactions for the current credit card.
+   */
+  async list(): Promise<Transaction[]> {
+    const all = await this.repository.findAll();
+    return all.filter((t) => t.source === "manual");
+  }
+}

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -489,23 +489,4 @@ export class TransactionController {
       });
     }
   };
-
-  /**
-   * Controlador para obtener la sumatoria de las cuotas por mes.
-   */
-  getMonthlyQuotaSum = async (req: Request, res: Response): Promise<void> => {
-    const { creditCardId } = req.params;
-
-    try {
-      const monthlyQuotaSum =
-        await this.service.getMonthlyQuotaSum(creditCardId);
-      res.status(200).json(monthlyQuotaSum);
-    } catch (error) {
-      console.error("Error al obtener la sumatoria de cuotas por mes:", error);
-      res.status(500).json({
-        message: "Error al obtener la sumatoria de cuotas por mes",
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-    }
-  };
 }

--- a/src/modules/transaction/transaction.routes.ts
+++ b/src/modules/transaction/transaction.routes.ts
@@ -101,13 +101,6 @@ const createTransactionRouter = (): Router => {
   );
 
   router.get(
-    "/creditCards/:creditCardId/transactions/monthly-sum",
-    (req: Request, res: Response) => {
-      return res.locals.transactionController.getMonthlyQuotaSum(req, res);
-    },
-  );
-
-  router.get(
     "/creditCards/:creditCardId/transactions/:transactionId",
     (req: Request, res: Response) => {
       return res.locals.transactionController.getTransaction(req, res);

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -4,29 +4,25 @@ import { TransactionRepository } from "./transaction.repository";
 import { Transaction } from "./transaction.model";
 import { BaseService } from "@/shared/classes/base.service";
 import { Quota } from "@/modules/quota/quota.model";
-import { BillingPeriodRepository } from "../billingPeriod/billingPeriod.repository";
-import {
-  CacheService,
-  CacheKeys,
-  CacheTTL,
-} from "@/shared/services/cache.service";
+import { BillingPeriodRepository } from "@modules/billingPeriod/billingPeriod.repository";
 import { EmailImportService } from "./emailImport.service";
+import { ManualTransactionService } from "./manualTransaction.service";
 
 export class TransactionService extends BaseService<Transaction> {
-  // Cambiar el tipo del repository para acceder a los métodos específicos
   protected repository: TransactionRepository;
   private billingPeriodRepository: BillingPeriodRepository;
   private emailImportService: EmailImportService;
+  private manualTransactionService: ManualTransactionService;
 
   constructor(
     repository: TransactionRepository,
     billingPeriodRepository: BillingPeriodRepository,
   ) {
     super(repository);
-    // Guardar la referencia al repository tipado
     this.repository = repository;
     this.billingPeriodRepository = billingPeriodRepository;
     this.emailImportService = new EmailImportService();
+    this.manualTransactionService = new ManualTransactionService(repository);
   }
 
   async fetchBankEmails(userId: string): Promise<{ importedCount: number }> {
@@ -216,69 +212,12 @@ export class TransactionService extends BaseService<Transaction> {
       quotaAmount: number;
       totalInstallments: number;
       paidInstallments: number;
-      lastPaidMonth: string; // "2026-01"
+      lastPaidMonth: string;
       currency: string;
       categoryId?: string;
     },
   ): Promise<{ transaction: Transaction; quotasCreated: number }> {
-    // Crear la transacción
-    const transactionId = this.repository.repository.doc().id;
-    const transaction: Transaction = {
-      id: transactionId,
-      amount: data.quotaAmount,
-      currency: data.currency,
-      cardType: "",
-      cardLastDigits: "",
-      merchant: data.merchant,
-      categoryId: data.categoryId,
-      transactionDate: new Date(data.purchaseDate),
-      bank: "manual",
-      email: "",
-      creditCardId,
-      source: "manual",
-      totalInstallments: data.totalInstallments,
-      paidInstallments: data.paidInstallments,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-    };
-
-    await this.repository.create(transaction);
-
-    // Generar cuotas
-    // lastPaidMonth es "2026-01" => la cuota paidInstallments se pagó en ese mes
-    // Las cuotas pendientes empiezan el mes siguiente
-    const [lastYear, lastMonthNum] = data.lastPaidMonth.split("-").map(Number);
-
-    for (let i = 1; i <= data.totalInstallments; i++) {
-      const isPaid = i <= data.paidInstallments;
-
-      // Calcular dueDate: cuotas van mes a mes
-      // Cuota paidInstallments cae en lastPaidMonth
-      // Offset from lastPaidMonth: i - paidInstallments
-      const monthOffset = i - data.paidInstallments;
-      const dueDate = new Date(lastYear, lastMonthNum - 1 + monthOffset, 15);
-
-      const quota: Quota = {
-        id: this.repository.repository.doc().id,
-        transactionId,
-        amount: data.quotaAmount,
-        dueDate: dueDate,
-        status: isPaid ? "paid" : "pending",
-        currency: data.currency,
-        paymentDate: isPaid ? dueDate : null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      };
-
-      await this.repository.addQuota(creditCardId, transactionId, quota);
-    }
-
-    return {
-      transaction,
-      quotasCreated: data.totalInstallments,
-    };
+    return this.manualTransactionService.create(creditCardId, data);
   }
 
   /**
@@ -288,24 +227,7 @@ export class TransactionService extends BaseService<Transaction> {
     creditCardId: string,
     transactionId: string,
   ): Promise<{ deletedQuotas: number }> {
-    const transaction = await this.repository.findById(transactionId);
-    if (!transaction) {
-      throw new Error("Transacción no encontrada");
-    }
-    if (transaction.source !== "manual") {
-      throw new Error("Solo se pueden eliminar transacciones manuales");
-    }
-
-    // Eliminar todas las cuotas primero
-    const deletedQuotas = await this.repository.deleteAllQuotas(
-      creditCardId,
-      transactionId,
-    );
-
-    // Eliminar la transacción (hard delete)
-    await this.repository.delete(transactionId);
-
-    return { deletedQuotas };
+    return this.manualTransactionService.delete(creditCardId, transactionId);
   }
 
   /**
@@ -325,65 +247,18 @@ export class TransactionService extends BaseService<Transaction> {
       categoryId?: string;
     },
   ): Promise<{ transaction: Transaction; quotasCreated: number }> {
-    const existing = await this.repository.findById(transactionId);
-    if (!existing) {
-      throw new Error("Transacción no encontrada");
-    }
-    if (existing.source !== "manual") {
-      throw new Error("Solo se pueden editar transacciones manuales");
-    }
-
-    // Actualizar la transacción
-    await this.repository.update(transactionId, {
-      merchant: data.merchant,
-      amount: data.quotaAmount,
-      ...(data.categoryId ? { categoryId: data.categoryId } : {}),
-      currency: data.currency,
-      transactionDate: new Date(data.purchaseDate),
-      totalInstallments: data.totalInstallments,
-      paidInstallments: data.paidInstallments,
-      updatedAt: new Date(),
-    } as Partial<Transaction>);
-
-    // Borrar todas las cuotas existentes y recrearlas
-    await this.repository.deleteAllQuotas(creditCardId, transactionId);
-
-    const [lastYear, lastMonthNum] = data.lastPaidMonth.split("-").map(Number);
-
-    for (let i = 1; i <= data.totalInstallments; i++) {
-      const isPaid = i <= data.paidInstallments;
-      const monthOffset = i - data.paidInstallments;
-      const dueDate = new Date(lastYear, lastMonthNum - 1 + monthOffset, 15);
-
-      const quota: Quota = {
-        id: this.repository.repository.doc().id,
-        transactionId,
-        amount: data.quotaAmount,
-        dueDate: dueDate,
-        status: isPaid ? "paid" : "pending",
-        currency: data.currency,
-        paymentDate: isPaid ? dueDate : null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        deletedAt: null,
-      };
-
-      await this.repository.addQuota(creditCardId, transactionId, quota);
-    }
-
-    const updated = await this.repository.findById(transactionId);
-    return {
-      transaction: updated!,
-      quotasCreated: data.totalInstallments,
-    };
+    return this.manualTransactionService.update(
+      creditCardId,
+      transactionId,
+      data,
+    );
   }
 
   /**
    * Lista solo las transacciones manuales de una tarjeta.
    */
   async getManualTransactions(): Promise<Transaction[]> {
-    const all = await this.repository.findAll();
-    return all.filter((t) => t.source === "manual");
+    return this.manualTransactionService.list();
   }
 
   async initializeQuotasForAllTransactions(
@@ -432,96 +307,5 @@ export class TransactionService extends BaseService<Transaction> {
     );
 
     return transactionsWithoutQuotas.length;
-  }
-
-  /**
-   * Obtiene la sumatoria de cuotas organizadas por períodos de facturación.
-   * Costo L3: 1 (billingPeriods) + 1 (transactions) + N_transactions (getQuotas) reads.
-   * Resultado cacheado en L1 memoria con TTL MEDIUM (2 min).
-   * Invalidación automática vía StatsService.triggerRecompute → CacheService.invalidateByPrefix.
-   */
-  async getMonthlyQuotaSum(
-    creditCardId: string,
-  ): Promise<{ period: string; currency: string; totalAmount: number }[]> {
-    // L1: memoria — clave por creditCardId (IDs de Firestore son globalmente únicos)
-    // Invalidación explícita vía StatsService.triggerRecompute cuando creditCardId es conocido
-    const cacheKey = CacheKeys.monthlyQuotaSum(creditCardId);
-    const cached =
-      CacheService.get<
-        { period: string; currency: string; totalAmount: number }[]
-      >(cacheKey);
-    if (cached !== null) return cached;
-
-    try {
-      const [billingPeriods, transactions] = await Promise.all([
-        this.billingPeriodRepository.findAll(),
-        this.repository.findAll(),
-      ]);
-
-      if (!billingPeriods.length || !transactions.length) return [];
-
-      const formattedBillingPeriods = billingPeriods.map((period) => ({
-        periodKey: `${convertUtcToChileTime(
-          period.startDate,
-          "yyyy-MM-dd",
-        )} - ${convertUtcToChileTime(period.endDate, "yyyy-MM-dd")}`,
-        startDate: new Date(
-          convertUtcToChileTime(period.startDate, "yyyy-MM-dd HH:mm:ss"),
-        ),
-        endDate: new Date(
-          convertUtcToChileTime(period.endDate, "yyyy-MM-dd HH:mm:ss"),
-        ),
-      }));
-
-      // N reads paralelas (una por transacción)
-      const allQuotas = (
-        await Promise.all(
-          transactions.map((tx) =>
-            this.repository.getQuotas(creditCardId, tx.id),
-          ),
-        )
-      ).flat();
-
-      const periodSumMap: { [key: string]: { [currency: string]: number } } =
-        {};
-
-      for (const billingPeriod of formattedBillingPeriods) {
-        periodSumMap[billingPeriod.periodKey] = {};
-        const quotasInPeriod = allQuotas.filter((quota) => {
-          if (!quota.dueDate) return false;
-          const quotaDate = new Date(
-            convertUtcToChileTime(quota.dueDate, "yyyy-MM-dd HH:mm:ss"),
-          );
-          return (
-            quotaDate >= billingPeriod.startDate &&
-            quotaDate <= billingPeriod.endDate
-          );
-        });
-        for (const quota of quotasInPeriod) {
-          periodSumMap[billingPeriod.periodKey][quota.currency] =
-            (periodSumMap[billingPeriod.periodKey][quota.currency] ?? 0) +
-            quota.amount;
-        }
-      }
-
-      const result = Object.entries(periodSumMap).flatMap(
-        ([period, currencyMap]) =>
-          Object.entries(currencyMap).map(([currency, totalAmount]) => ({
-            period,
-            currency,
-            totalAmount,
-          })),
-      );
-
-      if (cacheKey) CacheService.set(cacheKey, result, CacheTTL.MEDIUM);
-
-      return result;
-    } catch (error) {
-      console.error(
-        "Error al obtener la sumatoria de las cuotas por período de facturación:",
-        error,
-      );
-      throw error;
-    }
   }
 }


### PR DESCRIPTION
## Cambios

### ManualTransactionService (nuevo)
- Extraido CRUD de transacciones manuales + generacion de cuotas desde TransactionService
- Metodos: create, delete, update, list
- TransactionService delega a ManualTransactionService (mantiene API publica)

### getMonthlyQuotaSum -> StatsService
- Movido de TransactionService a StatsService (es logica de reporting)
- Ruta cambiada: /creditCards/:id/transactions/monthly-sum -> /creditCards/:id/stats/monthly-quota-sum
- Handler movido de TransactionController a StatsController
- Cache L1 con CacheService se mantiene

### Resultado
- TransactionService: ~466 -> ~280 lineas
- 8 archivos modificados, 0 breaking changes internos
- Build + lint OK