### PR TITLE
chore: validate env vars with Zod schema and typed getEnv()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ Existing issues to resolve progressively:
 9. `@Collection` decorator unused
 10. ~~No `req.body` validation~~ — Zod schemas added (PR #5)
 11. No tests
-12. Environment variables without validation
+12. ~~Environment variables without validation~~ — Zod schema in env.validation.ts, typed getEnv() (PR #14)
 13. ~~Currency inconsistency — "Dolar" vs "CLP"~~ — normalized to USD (PR #11)
 
 ---

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,22 +1,46 @@
 import dotenv from "dotenv";
+import { z } from "zod";
 
 dotenv.config();
 
-const REQUIRED_ENV_VARS = [
-  "SERVICE_ACCOUNT_KEY",
-  "FIREBASE_DB_URL",
-  "JWT_SECRET",
-  "JWT_REFRESH_SECRET",
-  "GOOGLE_CLIENT_ID",
-] as const;
+const envSchema = z.object({
+  // Required
+  SERVICE_ACCOUNT_KEY: z.string().min(1),
+  FIREBASE_DB_URL: z.string().url(),
+  JWT_SECRET: z.string().min(1),
+  JWT_REFRESH_SECRET: z.string().min(1),
+  GOOGLE_CLIENT_ID: z.string().min(1),
+
+  // Optional
+  PORT: z.coerce.number().int().positive().default(3000),
+  ALLOWED_ORIGINS: z.string().default(""),
+  ACCESS_TOKEN_EXPIRES_IN: z.string().default("15m"),
+  REFRESH_TOKEN_EXPIRES_IN: z.string().default("30d"),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+  CREDENTIALS_JSON: z.string().optional(),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+let _env: Env | undefined;
 
 export function validateEnv(): void {
-  const missing = REQUIRED_ENV_VARS.filter((key) => !process.env[key]?.trim());
+  const result = envSchema.safeParse(process.env);
 
-  if (missing.length > 0) {
-    console.error(
-      `Missing required environment variables: ${missing.join(", ")}`,
-    );
+  if (!result.success) {
+    console.error("Invalid environment variables:");
+    for (const issue of result.error.issues) {
+      console.error(`  ${issue.path.join(".")}: ${issue.message}`);
+    }
     process.exit(1);
   }
+
+  _env = result.data;
+}
+
+export function getEnv(): Env {
+  if (!_env) {
+    throw new Error("Environment not validated. Call validateEnv() first.");
+  }
+  return _env;
 }

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -1,20 +1,17 @@
 import admin from "firebase-admin";
-import dotenv from "dotenv";
+import { getEnv } from "@config/env.validation";
 
-dotenv.config();
-
-// Configuración de Firebase
-//const serviceAccount = require(path.join(__dirname, 'serviceAccountKey.json'));
+const env = getEnv();
 
 const serviceAccountJson = Buffer.from(
-  process.env.SERVICE_ACCOUNT_KEY!,
+  env.SERVICE_ACCOUNT_KEY,
   "base64",
 ).toString("utf8");
 const serviceAccount = JSON.parse(serviceAccountJson);
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: process.env.FIREBASE_DB_URL,
+  databaseURL: env.FIREBASE_DB_URL,
 });
 
 // Inicializar Firestore y Fireorm

--- a/src/config/gmailAuth.ts
+++ b/src/config/gmailAuth.ts
@@ -1,6 +1,7 @@
 import { google, Auth } from "googleapis";
 import readline from "readline";
 import { db } from "@/config/firebase";
+import { getEnv } from "@config/env.validation";
 
 const SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",
@@ -9,16 +10,16 @@ const SCOPES = [
 
 // Decodificar credenciales desde variable de entorno
 function getGoogleCredentials(): Auth.OAuth2Client {
-  if (!process.env.CREDENTIALS_JSON) {
+  const env = getEnv();
+  if (!env.CREDENTIALS_JSON) {
     throw new Error(
       "CREDENTIALS_JSON no está definido en las variables de entorno.",
     );
   }
 
-  const credentialsJson = Buffer.from(
-    process.env.CREDENTIALS_JSON,
-    "base64",
-  ).toString("utf8");
+  const credentialsJson = Buffer.from(env.CREDENTIALS_JSON, "base64").toString(
+    "utf8",
+  );
   const credentials = JSON.parse(credentialsJson);
 
   const { client_secret, client_id } = credentials.installed;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { validateEnv } from "./config/env.validation";
+import { validateEnv, getEnv } from "./config/env.validation";
 validateEnv();
 
 import "./config/firebase";
@@ -18,6 +18,7 @@ import createStatsRouter from "./modules/stats/stats.routes";
 import createCategoryRouter from "./modules/category";
 
 const app = express();
+const env = getEnv();
 
 // Behind reverse proxy (Render, etc.) — needed for rate limiting & correct client IP
 app.set("trust proxy", 1);
@@ -25,8 +26,8 @@ app.set("trust proxy", 1);
 // --- Security middleware ---
 app.use(helmet());
 
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(",")
+const allowedOrigins = env.ALLOWED_ORIGINS
+  ? env.ALLOWED_ORIGINS.split(",")
   : [];
 
 app.use(
@@ -73,7 +74,6 @@ app.use("/api/categories", createCategoryRouter());
 
 app.use(errorHandler);
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.warn(`Servidor ejecutándose en el puerto ${PORT}`);
+app.listen(env.PORT, () => {
+  console.warn(`Servidor ejecutándose en el puerto ${env.PORT}`);
 });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -5,6 +5,7 @@ import { User } from "@modules/user/user.model";
 import { AuthError } from "@shared/errors/custom.error";
 import { saveTokenToFirestore } from "@/config/gmailAuth";
 import { RevokedTokenRepository } from "./revokedToken.repository";
+import { getEnv } from "@config/env.validation";
 
 export class AuthService {
   constructor(
@@ -16,13 +17,8 @@ export class AuthService {
     idToken: string,
     serverAuthCode?: string,
   ): Promise<{ accessToken: string; refreshToken: string }> {
-    const clientId = process.env.GOOGLE_CLIENT_ID;
-    if (!clientId) {
-      throw new AuthError(
-        "GOOGLE_CLIENT_ID no configurado en variables de entorno",
-        500,
-      );
-    }
+    const env = getEnv();
+    const clientId = env.GOOGLE_CLIENT_ID;
 
     // Verificar el `idToken` con Google
     const client = new OAuth2Client(clientId);
@@ -80,7 +76,7 @@ export class AuthService {
       try {
         const oAuth2Client = new OAuth2Client(
           clientId,
-          process.env.GOOGLE_CLIENT_SECRET,
+          env.GOOGLE_CLIENT_SECRET,
           "", // redirect_uri vacío para mobile
         );
         const { tokens } = await oAuth2Client.getToken(serverAuthCode);
@@ -93,15 +89,14 @@ export class AuthService {
     }
 
     // Generar access token (corto) y refresh token (largo)
-    const jwtSecret = process.env.JWT_SECRET as jwt.Secret;
+    const jwtSecret = env.JWT_SECRET as jwt.Secret;
     const accessToken = jwt.sign({ userId, email, type: "access" }, jwtSecret, {
-      expiresIn: process.env.ACCESS_TOKEN_EXPIRES_IN || "15m",
+      expiresIn: env.ACCESS_TOKEN_EXPIRES_IN,
     } as jwt.SignOptions);
 
-    const refreshSecret =
-      (process.env.JWT_REFRESH_SECRET as jwt.Secret) || jwtSecret;
+    const refreshSecret = env.JWT_REFRESH_SECRET as jwt.Secret;
     const refreshToken = jwt.sign({ userId, type: "refresh" }, refreshSecret, {
-      expiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN || "30d",
+      expiresIn: env.REFRESH_TOKEN_EXPIRES_IN,
     } as jwt.SignOptions);
 
     return { accessToken, refreshToken };
@@ -109,8 +104,8 @@ export class AuthService {
 
   async refreshTokens(refreshToken: string) {
     try {
-      const refreshSecret =
-        process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET!;
+      const env = getEnv();
+      const refreshSecret = env.JWT_REFRESH_SECRET;
       const decoded = jwt.verify(refreshToken, refreshSecret) as {
         userId: string;
         type?: string;
@@ -121,7 +116,8 @@ export class AuthService {
       }
 
       // Verificar si el token fue revocado
-      const isRevoked = await this.revokedTokenRepository.isRevoked(refreshToken);
+      const isRevoked =
+        await this.revokedTokenRepository.isRevoked(refreshToken);
       if (isRevoked) {
         throw new Error("Refresh token revocado");
       }
@@ -129,12 +125,12 @@ export class AuthService {
       const user = await this.userRepository.findById(decoded.userId);
       if (!user) throw new Error("Usuario no encontrado");
 
-      const jwtSecret = process.env.JWT_SECRET as jwt.Secret;
+      const jwtSecret = env.JWT_SECRET as jwt.Secret;
       const accessToken = jwt.sign(
         { userId: user.id, email: user.email, type: "access" },
         jwtSecret,
         {
-          expiresIn: process.env.ACCESS_TOKEN_EXPIRES_IN || "15m",
+          expiresIn: env.ACCESS_TOKEN_EXPIRES_IN,
         } as jwt.SignOptions,
       );
 
@@ -142,7 +138,7 @@ export class AuthService {
         { userId: user.id, type: "refresh" },
         refreshSecret,
         {
-          expiresIn: process.env.REFRESH_TOKEN_EXPIRES_IN || "30d",
+          expiresIn: env.REFRESH_TOKEN_EXPIRES_IN,
         } as jwt.SignOptions,
       );
 
@@ -161,8 +157,7 @@ export class AuthService {
 
   async logout(refreshToken: string): Promise<void> {
     try {
-      const refreshSecret =
-        process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET!;
+      const refreshSecret = getEnv().JWT_REFRESH_SECRET;
       const decoded = jwt.verify(refreshToken, refreshSecret) as {
         exp?: number;
       };

--- a/src/modules/transaction/emailImport.service.ts
+++ b/src/modules/transaction/emailImport.service.ts
@@ -3,6 +3,7 @@ import { getTokenFromFirestore } from "@config/gmailAuth";
 import * as cheerio from "cheerio";
 import { chunkArray } from "@/shared/utils/array.utils";
 import { parseFirebaseDate } from "@/shared/utils/date.utils";
+import { getEnv } from "@config/env.validation";
 
 import { TransactionRepository } from "./transaction.repository";
 import { Transaction } from "./transaction.model";
@@ -33,8 +34,9 @@ export class EmailImportService {
       );
     }
 
-    const clientId = process.env.GOOGLE_CLIENT_ID;
-    const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    const env = getEnv();
+    const clientId = env.GOOGLE_CLIENT_ID;
+    const clientSecret = env.GOOGLE_CLIENT_SECRET;
     const auth: Auth.OAuth2Client = new google.auth.OAuth2(
       clientId,
       clientSecret,

--- a/src/shared/middlewares/auth.middleware.ts
+++ b/src/shared/middlewares/auth.middleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
+import { getEnv } from "@config/env.validation";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -25,7 +26,7 @@ export const authenticate = (
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as {
+    const decoded = jwt.verify(token, getEnv().JWT_SECRET) as {
       userId: string;
     };
 
@@ -40,13 +41,11 @@ export const authenticate = (
     console.error("Error en autenticación:", error);
     // Diferenciar expiración para que el cliente pueda intentar refresh
     if (error instanceof jwt.TokenExpiredError) {
-      res
-        .status(401)
-        .json({
-          message: "Token expirado",
-          code: "token_expired",
-          expiredAt: error.expiredAt,
-        });
+      res.status(401).json({
+        message: "Token expirado",
+        code: "token_expired",
+        expiredAt: error.expiredAt,
+      });
       return;
     }
 


### PR DESCRIPTION
## Cambios

### env.validation.ts (reescrito)
- Reemplaza validacion basica (array de strings) con Zod schema tipado
- Exporta getEnv() que retorna objeto tipado con todas las env vars
- Vars requeridas fallan al inicio con mensajes claros por campo
- Vars opcionales con defaults: PORT=3000, ACCESS_TOKEN_EXPIRES_IN=15m, REFRESH_TOKEN_EXPIRES_IN=30d

### Archivos actualizados (process.env -> getEnv())
- firebase.ts: SERVICE_ACCOUNT_KEY, FIREBASE_DB_URL
- index.ts: ALLOWED_ORIGINS, PORT
- auth.middleware.ts: JWT_SECRET
- auth.service.ts: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, JWT_SECRET, JWT_REFRESH_SECRET, token expiry
- emailImport.service.ts: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
- gmailAuth.ts: CREDENTIALS_JSON

### Beneficios
- Falla al arrancar, no en runtime
- Tipo seguro: sin non-null assertions (!) en process.env
- Defaults centralizados (antes duplicados en auth.service.ts)
- Build + lint OK