### PR TITLE
refactor: fix repository boundary violations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Before delivering code:
 Existing issues to resolve progressively:
 
 1. ~~`TransactionService` too large (~740 lines)~~ — EmailImportService, ManualTransactionService extracted, getMonthlyQuotaSum moved to StatsService (~280 lines remaining)
-2. Repository boundary violations — repos accessing other collections
+2. ~~Repository boundary violations~~ — TransactionRepository no longer depends on CreditCardRepository; cross-card logic moved to EmailImportService (PR #16)
 3. ~~`stats` module incomplete~~ — empty repository deleted (PR #9)
 4. ~~`UserService` constructor bug~~ — fixed (PR #8)
 5. ~~`MerchantPattern` doesn't follow pattern~~ — now implements IBaseEntity (PR #9)

--- a/src/modules/transaction/emailImport.service.ts
+++ b/src/modules/transaction/emailImport.service.ts
@@ -5,7 +5,7 @@ import { chunkArray } from "@/shared/utils/array.utils";
 import { parseFirebaseDate } from "@/shared/utils/date.utils";
 import { getEnv } from "@config/env.validation";
 
-import { TransactionRepository } from "./transaction.repository";
+import { CreditCardRepository } from "@modules/creditCard/creditCard.repository";
 import { Transaction } from "./transaction.model";
 import { CategoryService } from "@/modules/category/category.service";
 
@@ -24,7 +24,7 @@ export class EmailImportService {
    */
   async fetchBankEmails(
     userId: string,
-    repository: TransactionRepository,
+    creditCardRepository: CreditCardRepository,
   ): Promise<{ importedCount: number }> {
     const tokenData = await getTokenFromFirestore(userId);
 
@@ -90,7 +90,10 @@ export class EmailImportService {
     }
 
     const messageIds = res.data.messages.map((message) => message.id!);
-    const existingIds = await repository.getExistingTransactionIds(messageIds);
+    const existingIds = await this.getExistingTransactionIds(
+      creditCardRepository,
+      messageIds,
+    );
     const newMessageIds = messageIds.filter((id) => !existingIds.includes(id));
 
     if (newMessageIds.length === 0) {
@@ -170,12 +173,60 @@ export class EmailImportService {
 
       if (batchData.length > 0) {
         totalImported += batchData.length;
-        await repository.saveBatch(batchData);
+        await this.saveBatch(creditCardRepository, batchData);
         batchData = [];
       }
     }
 
     return { importedCount: totalImported };
+  }
+
+  /**
+   * Checks which transaction IDs already exist across all credit cards.
+   */
+  private async getExistingTransactionIds(
+    creditCardRepository: CreditCardRepository,
+    ids: string[],
+  ): Promise<string[]> {
+    const creditCards = await creditCardRepository.findAll();
+    const chunks = chunkArray(ids, 10);
+    const results = await Promise.all(
+      chunks.map(async (chunk) => {
+        const matched: string[] = [];
+        for (const creditCard of creditCards) {
+          const txCollection = creditCardRepository.getTransactionsCollection(
+            creditCard.id,
+          );
+          const snapshot = await txCollection
+            .where("id", "in", chunk)
+            .where("deletedAt", "==", null)
+            .get();
+          matched.push(...snapshot.docs.map((doc) => doc.id));
+        }
+        return matched;
+      }),
+    );
+    return results.flat();
+  }
+
+  /**
+   * Saves a batch of transactions, matching each to its credit card by cardLastDigits.
+   */
+  private async saveBatch(
+    creditCardRepository: CreditCardRepository,
+    transactions: Transaction[],
+  ): Promise<void> {
+    await Promise.all(
+      transactions.map(async (transaction) => {
+        const creditCard = await creditCardRepository.findOne({
+          cardLastDigits: transaction.cardLastDigits,
+        });
+        if (creditCard) {
+          transaction.creditCardId = creditCard.id;
+          await creditCardRepository.addTransaction(creditCard.id, transaction);
+        }
+      }),
+    );
   }
 
   /**

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -1,26 +1,18 @@
 import { FirestoreRepository } from "@/shared/classes/firestore.repository";
 import { Transaction } from "./transaction.model";
-import { chunkArray } from "@/shared/utils/array.utils";
-import { CreditCardRepository } from "@/modules/creditCard/creditCard.repository";
 import { Quota } from "@/modules/quota/quota.model";
 
 export class TransactionRepository extends FirestoreRepository<Transaction> {
-  private creditCardRepository: CreditCardRepository;
-
   constructor(userId: string, creditCardId: string) {
     super(["users", userId, "creditCards", creditCardId], "transactions");
-
-    this.creditCardRepository = new CreditCardRepository(userId);
   }
 
-  // Obtener la referencia a la subcolección de cuotas dentro de la subcolección de transacciones de una tarjeta de crédito
+  // Obtener la referencia a la subcolección de cuotas dentro de una transacción
   getQuotasCollection(
-    creditCardId: string,
+    _creditCardId: string,
     transactionId: string,
   ): FirebaseFirestore.CollectionReference<Quota> {
-    return this.creditCardRepository.repository
-      .doc(creditCardId)
-      .collection("transactions")
+    return this.repository
       .doc(transactionId)
       .collection("quotas") as FirebaseFirestore.CollectionReference<Quota>;
   }
@@ -76,65 +68,9 @@ export class TransactionRepository extends FirestoreRepository<Transaction> {
       transactionId,
     );
     const snapshot = await quotasCollection.get();
-    const batch = this.creditCardRepository.repository.firestore.batch();
+    const batch = this.repository.firestore.batch();
     snapshot.docs.forEach((doc) => batch.delete(doc.ref));
     await batch.commit();
     return snapshot.size;
-  }
-
-  // Obtener IDs de transacciones existentes en Firestore y en CreditCard
-  async getExistingTransactionIds(ids: string[]): Promise<string[]> {
-    // Cargar tarjetas UNA sola vez fuera del loop de chunks
-    const creditCards = await this.creditCardRepository.findAll();
-    const chunks = chunkArray(ids, 10);
-    const results = await Promise.all(
-      chunks.map(async (chunk) => {
-        const creditCardTransactionIds: string[] = [];
-        for (const creditCard of creditCards) {
-          const transactionsCollection =
-            this.creditCardRepository.getTransactionsCollection(creditCard.id);
-          const transactionSnapshot = await transactionsCollection
-            .where("id", "in", chunk)
-            .where("deletedAt", "==", null)
-            .get();
-          creditCardTransactionIds.push(
-            ...transactionSnapshot.docs.map((doc) => doc.id),
-          );
-        }
-        return creditCardTransactionIds;
-      }),
-    );
-    return results.flat();
-  }
-
-  // Guardar un lote de transacciones y actualiza la tarjeta de crédito correspondiente
-  // Guardar un lote de transacciones y actualiza la tarjeta de crédito correspondiente
-  async saveBatch(transactions: Transaction[]): Promise<void> {
-    try {
-      await Promise.all(
-        transactions.map(async (transaction) => {
-          // Actualizar la tarjeta de crédito correspondiente
-          const creditCard = await this.creditCardRepository.findOne({
-            cardLastDigits: transaction.cardLastDigits,
-          });
-          if (creditCard) {
-            transaction.creditCardId = creditCard.id; // Establece el creditCardId
-            await this.creditCardRepository.addTransaction(
-              creditCard.id,
-              transaction,
-            );
-          }
-        }),
-      );
-      console.warn(
-        `Lote de transacciones guardado exitosamente en Firestore. Total de registros: ${transactions.length}`,
-      );
-    } catch (error) {
-      console.error(
-        "Error al guardar el lote de transacciones en Firestore:",
-        error,
-      );
-      throw error; // Propaga el error para manejo en niveles superiores
-    }
   }
 }

--- a/src/modules/transaction/transaction.routes.ts
+++ b/src/modules/transaction/transaction.routes.ts
@@ -3,7 +3,8 @@ import { TransactionController } from "./transaction.controller";
 import { TransactionRepository } from "./transaction.repository";
 import { TransactionService } from "./transaction.service";
 import { authenticate } from "@/shared/middlewares/auth.middleware";
-import { BillingPeriodRepository } from "../billingPeriod/billingPeriod.repository";
+import { BillingPeriodRepository } from "@modules/billingPeriod/billingPeriod.repository";
+import { CreditCardRepository } from "@modules/creditCard/creditCard.repository";
 import { validate } from "@shared/middlewares/validate.middleware";
 import {
   createTransactionSchema,
@@ -38,9 +39,11 @@ const createTransactionRouter = (): Router => {
           userId,
           creditCardId,
         );
+        const creditCardRepository = new CreditCardRepository(userId);
         const service = new TransactionService(
           transactionRepository,
           billingPeriodRepository,
+          creditCardRepository,
         );
         const controller = new TransactionController(service);
 

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -5,28 +5,35 @@ import { Transaction } from "./transaction.model";
 import { BaseService } from "@/shared/classes/base.service";
 import { Quota } from "@/modules/quota/quota.model";
 import { BillingPeriodRepository } from "@modules/billingPeriod/billingPeriod.repository";
+import { CreditCardRepository } from "@modules/creditCard/creditCard.repository";
 import { EmailImportService } from "./emailImport.service";
 import { ManualTransactionService } from "./manualTransaction.service";
 
 export class TransactionService extends BaseService<Transaction> {
   protected repository: TransactionRepository;
   private billingPeriodRepository: BillingPeriodRepository;
+  private creditCardRepository: CreditCardRepository;
   private emailImportService: EmailImportService;
   private manualTransactionService: ManualTransactionService;
 
   constructor(
     repository: TransactionRepository,
     billingPeriodRepository: BillingPeriodRepository,
+    creditCardRepository: CreditCardRepository,
   ) {
     super(repository);
     this.repository = repository;
     this.billingPeriodRepository = billingPeriodRepository;
+    this.creditCardRepository = creditCardRepository;
     this.emailImportService = new EmailImportService();
     this.manualTransactionService = new ManualTransactionService(repository);
   }
 
   async fetchBankEmails(userId: string): Promise<{ importedCount: number }> {
-    return this.emailImportService.fetchBankEmails(userId, this.repository);
+    return this.emailImportService.fetchBankEmails(
+      userId,
+      this.creditCardRepository,
+    );
   }
 
   /**


### PR DESCRIPTION
## Problema
TransactionRepository importaba y usaba CreditCardRepository internamente, violando la regla de que repos solo deben manejar su propia coleccion.

## Cambios

### TransactionRepository (limpiado)
- Eliminada dependencia de CreditCardRepository (import + constructor)
- getQuotasCollection: ahora usa this.repository.doc(txId).collection('quotas') directamente
- deleteAllQuotas: usa this.repository.firestore.batch() en vez de creditCardRepo
- Removidos getExistingTransactionIds y saveBatch (eran operaciones cross-card)

### EmailImportService (absorbe logica cross-card)
- Recibe CreditCardRepository en vez de TransactionRepository
- Nuevos metodos privados: getExistingTransactionIds, saveBatch
- La logica cross-card vive ahora en el servicio (aceptable via DI) en vez del repo

### TransactionService + Routes
- Constructor recibe CreditCardRepository (3er parametro)
- Routes crea e inyecta CreditCardRepository

## Principio
- Repos: solo su coleccion
- Services: pueden recibir repos de otros modulos via DI (patron del proyecto)

Build + lint OK