### PR TITLE
docs: update AGENTS.md and skills to reflect current patterns

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,6 +61,8 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Modifying backend models        | `sync-types`         |
 | Syncing types with frontend     | `sync-types`         |
 | Adding fields to entities       | `sync-types`         |
+| Adding request validation       | `myquota-routes`     |
+| Creating Zod schemas            | `myquota-routes`     |
 
 ## <!-- Skills extracted from metadata.auto_invoke in each SKILL.md -->
 
@@ -68,12 +70,14 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Dato     | Valor                                   |
 | -------- | --------------------------------------- |
-| Runtime  | Node 22 + Express 4                     |
-| Language | TypeScript 5.6 (strict)                 |
-| Database | Firestore (firebase-admin)              |
-| Auth     | Google Sign-In → JWT (access + refresh) |
-| Linting  | ESLint 9 (flat config)                  |
-| Deploy   | Render                                  |
+| Runtime     | Node 22 + Express 4                     |
+| Language    | TypeScript 5.6 (strict)                 |
+| Database    | Firestore (firebase-admin)              |
+| Auth        | Google Sign-In → JWT (access + refresh) |
+| Validation  | Zod 4 (req.body + env vars)             |
+| Security    | helmet + cors + express-rate-limit      |
+| Linting     | ESLint 9 (flat config)                  |
+| Deploy      | Render                                  |
 
 **Entry point**: `src/index.ts` — mounts routers + errorHandler
 
@@ -84,10 +88,12 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 ```
 src/
 ├── index.ts                    # Express app, mounts routers
-├── config/                     # Firebase, Gmail OAuth
+├── config/                     # Firebase, Gmail OAuth, env validation
+│   └── env.validation.ts       # Zod schema for env vars, getEnv()
 ├── modules/                    # Feature-based modules
 │   └── <module>/
 │       ├── <module>.model.ts
+│       ├── <module>.schemas.ts  # Zod schemas for req.body validation
 │       ├── <module>.repository.ts
 │       ├── <module>.service.ts
 │       ├── <module>.controller.ts
@@ -95,10 +101,13 @@ src/
 └── shared/                     # Shared code
     ├── classes/                # BaseService, FirestoreRepository
     ├── interfaces/             # IBaseEntity, IBaseRepository
-    ├── middlewares/            # authenticate, errorHandler
+    ├── middlewares/            # authenticate, errorHandler, validate
+    ├── services/               # CacheService (in-memory TTL cache)
     ├── errors/                 # RepositoryError, AuthError
     └── utils/                  # date.utils, array.utils
 ```
+
+**Módulos con sub-servicios**: Módulos complejos pueden tener servicios especializados adicionales (e.g., `emailImport.service.ts`, `manualTransaction.service.ts`) que manejan concerns específicos extraídos del servicio principal.
 
 ---
 
@@ -114,6 +123,9 @@ src/
 6. **Arrow functions** en controllers
 7. **try/catch** en cada método de controller
 8. **`error instanceof Error ? error.message : "Error desconocido"`** para extraer mensajes
+9. **`getEnv()`** para acceder a variables de entorno — importar de `@config/env.validation`
+10. **Zod schemas + `validate()` middleware** para validar `req.body` en rutas con POST/PUT
+11. **`<module>.schemas.ts`** para definir Zod schemas de cada módulo
 
 ### NEVER
 
@@ -123,6 +135,8 @@ src/
 4. **Rutas relativas** (`../../`) fuera del módulo
 5. **`console.log`** en código nuevo — solo `console.error` en catches
 6. **Pasar objeto `error` raw** a `res.json()` — siempre extraer `.message`
+7. **`process.env`** directo — siempre usar `getEnv()` de `@config/env.validation`
+8. **`req.body` sin validar** — siempre usar Zod schema + `validate()` middleware
 
 ---
 
@@ -183,13 +197,21 @@ npm run lint     # ESLint check
 
 ## Environment Variables
 
-| Variable              | Propósito                  | Required   |
-| --------------------- | -------------------------- | ---------- |
-| `SERVICE_ACCOUNT_KEY` | Firebase SA (base64)       | Yes (prod) |
-| `FIREBASE_DB_URL`     | Firestore URL              | Yes        |
-| `JWT_SECRET`          | JWT signing                | Yes        |
-| `JWT_REFRESH_SECRET`  | Refresh token signing      | Yes        |
-| `PORT`                | Server port (default 3000) | No         |
+Validadas con Zod en `src/config/env.validation.ts`. Acceder siempre via `getEnv()`.
+
+| Variable                  | Propósito                           | Required |
+| ------------------------- | ----------------------------------- | -------- |
+| `SERVICE_ACCOUNT_KEY`     | Firebase SA (base64)                | Yes      |
+| `FIREBASE_DB_URL`         | Firestore URL                       | Yes      |
+| `JWT_SECRET`              | JWT signing                         | Yes      |
+| `JWT_REFRESH_SECRET`      | Refresh token signing               | Yes      |
+| `GOOGLE_CLIENT_ID`        | Google OAuth client ID              | Yes      |
+| `PORT`                    | Server port (default 3000)          | No       |
+| `ALLOWED_ORIGINS`         | CORS origins comma-separated        | No       |
+| `ACCESS_TOKEN_EXPIRES_IN` | Access token TTL (default "15m")    | No       |
+| `REFRESH_TOKEN_EXPIRES_IN`| Refresh token TTL (default "30d")   | No       |
+| `GOOGLE_CLIENT_SECRET`    | Google OAuth client secret          | No       |
+| `CREDENTIALS_JSON`        | Gmail API credentials               | No       |
 
 ---
 
@@ -211,6 +233,9 @@ Before delivering code:
 - [ ] `npm run lint` passes
 - [ ] Entity fields are camelCase
 - [ ] No unnecessary `console.log` (only `console.error` in catches)
+- [ ] POST/PUT routes use `validate(zodSchema)` middleware
+- [ ] Zod schemas defined in `<module>.schemas.ts` with `.strict()`
+- [ ] Environment access via `getEnv()`, never `process.env`
 
 ---
 
@@ -218,33 +243,36 @@ Before delivering code:
 
 Existing issues to resolve progressively:
 
-1. `TransactionService` too large (~740 lines) — extract to specialized services
-2. Repository boundary violations — repos accessing other collections
-3. `stats` module incomplete — empty repository, unused interfaces
-4. `UserService` constructor bug — ignores injected repository
-5. `MerchantPattern` doesn't follow pattern — no IBaseEntity
-6. snake_case in `Quota` model — `due_date`, `payment_date`
-7. Excessive console.log with emojis
-8. `errorHandler` debug leftovers
-9. `@Collection` decorator unused
-10. No `req.body` validation — future: add Zod
+1. ~~`TransactionService` too large (~740 lines)~~ — EmailImportService, ManualTransactionService extracted, getMonthlyQuotaSum moved to StatsService (~280 lines remaining)
+2. ~~Repository boundary violations~~ — TransactionRepository no longer depends on CreditCardRepository; cross-card logic moved to EmailImportService (PR #16)
+3. ~~`stats` module incomplete~~ — empty repository deleted (PR #9)
+4. ~~`UserService` constructor bug~~ — fixed (PR #8)
+5. ~~`MerchantPattern` doesn't follow pattern~~ — now implements IBaseEntity (PR #9)
+6. ~~snake_case in `Quota` model~~ — migrated to camelCase (PR #10)
+7. ~~Excessive console.log with emojis~~ — cleaned up (PR #8)
+8. ~~`errorHandler` debug leftovers~~ — hardened (PR #8)
+9. ~~`@Collection` decorator unused~~ — fireorm remnants cleaned up (PR #15)
+10. ~~No `req.body` validation~~ — Zod schemas added (PR #5)
 11. No tests
-12. Environment variables without validation
-13. Currency inconsistency — "Dolar" vs "CLP"
+12. ~~Environment variables without validation~~ — Zod schema in env.validation.ts, typed getEnv() (PR #14)
+13. ~~Currency inconsistency — "Dolar" vs "CLP"~~ — normalized to USD (PR #11)
 
 ---
 
 ## Key Files
 
-| File                                         | Purpose                      |
-| -------------------------------------------- | ---------------------------- |
-| `src/index.ts`                               | Express app, router mounting |
-| `src/config/firebase.ts`                     | Firebase init, exports `db`  |
-| `src/shared/classes/firestore.repository.ts` | Generic Firestore CRUD       |
-| `src/shared/classes/base.service.ts`         | Generic service CRUD         |
-| `src/shared/middlewares/auth.middleware.ts`  | JWT authentication           |
-| `src/shared/errors/custom.error.ts`          | RepositoryError, AuthError   |
-| `src/shared/utils/date.utils.ts`             | Chile timezone utilities     |
+| File                                            | Purpose                            |
+| ----------------------------------------------- | ---------------------------------- |
+| `src/index.ts`                                  | Express app, router mounting       |
+| `src/config/firebase.ts`                        | Firebase init, exports `db`        |
+| `src/config/env.validation.ts`                  | Zod env schema, `getEnv()`         |
+| `src/shared/classes/firestore.repository.ts`    | Generic Firestore CRUD             |
+| `src/shared/classes/base.service.ts`            | Generic service CRUD               |
+| `src/shared/middlewares/auth.middleware.ts`      | JWT authentication                 |
+| `src/shared/middlewares/validate.middleware.ts`  | Zod req.body validation middleware |
+| `src/shared/services/cache.service.ts`           | In-memory TTL cache + CacheKeys    |
+| `src/shared/errors/custom.error.ts`             | RepositoryError, AuthError         |
+| `src/shared/utils/date.utils.ts`                | Chile timezone utilities           |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Modifying backend models        | `sync-types`         |
 | Syncing types with frontend     | `sync-types`         |
 | Adding fields to entities       | `sync-types`         |
+| Adding request validation       | `myquota-routes`     |
+| Creating Zod schemas            | `myquota-routes`     |
 
 ## <!-- Skills extracted from metadata.auto_invoke in each SKILL.md -->
 
@@ -68,12 +70,14 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
 | Dato     | Valor                                   |
 | -------- | --------------------------------------- |
-| Runtime  | Node 22 + Express 4                     |
-| Language | TypeScript 5.6 (strict)                 |
-| Database | Firestore (firebase-admin)              |
-| Auth     | Google Sign-In → JWT (access + refresh) |
-| Linting  | ESLint 9 (flat config)                  |
-| Deploy   | Render                                  |
+| Runtime     | Node 22 + Express 4                     |
+| Language    | TypeScript 5.6 (strict)                 |
+| Database    | Firestore (firebase-admin)              |
+| Auth        | Google Sign-In → JWT (access + refresh) |
+| Validation  | Zod 4 (req.body + env vars)             |
+| Security    | helmet + cors + express-rate-limit      |
+| Linting     | ESLint 9 (flat config)                  |
+| Deploy      | Render                                  |
 
 **Entry point**: `src/index.ts` — mounts routers + errorHandler
 
@@ -84,10 +88,12 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 ```
 src/
 ├── index.ts                    # Express app, mounts routers
-├── config/                     # Firebase, Gmail OAuth
+├── config/                     # Firebase, Gmail OAuth, env validation
+│   └── env.validation.ts       # Zod schema for env vars, getEnv()
 ├── modules/                    # Feature-based modules
 │   └── <module>/
 │       ├── <module>.model.ts
+│       ├── <module>.schemas.ts  # Zod schemas for req.body validation
 │       ├── <module>.repository.ts
 │       ├── <module>.service.ts
 │       ├── <module>.controller.ts
@@ -95,10 +101,13 @@ src/
 └── shared/                     # Shared code
     ├── classes/                # BaseService, FirestoreRepository
     ├── interfaces/             # IBaseEntity, IBaseRepository
-    ├── middlewares/            # authenticate, errorHandler
+    ├── middlewares/            # authenticate, errorHandler, validate
+    ├── services/               # CacheService (in-memory TTL cache)
     ├── errors/                 # RepositoryError, AuthError
     └── utils/                  # date.utils, array.utils
 ```
+
+**Módulos con sub-servicios**: Módulos complejos pueden tener servicios especializados adicionales (e.g., `emailImport.service.ts`, `manualTransaction.service.ts`) que manejan concerns específicos extraídos del servicio principal.
 
 ---
 
@@ -114,6 +123,9 @@ src/
 6. **Arrow functions** en controllers
 7. **try/catch** en cada método de controller
 8. **`error instanceof Error ? error.message : "Error desconocido"`** para extraer mensajes
+9. **`getEnv()`** para acceder a variables de entorno — importar de `@config/env.validation`
+10. **Zod schemas + `validate()` middleware** para validar `req.body` en rutas con POST/PUT
+11. **`<module>.schemas.ts`** para definir Zod schemas de cada módulo
 
 ### NEVER
 
@@ -123,6 +135,8 @@ src/
 4. **Rutas relativas** (`../../`) fuera del módulo
 5. **`console.log`** en código nuevo — solo `console.error` en catches
 6. **Pasar objeto `error` raw** a `res.json()` — siempre extraer `.message`
+7. **`process.env`** directo — siempre usar `getEnv()` de `@config/env.validation`
+8. **`req.body` sin validar** — siempre usar Zod schema + `validate()` middleware
 
 ---
 
@@ -183,13 +197,21 @@ npm run lint     # ESLint check
 
 ## Environment Variables
 
-| Variable              | Propósito                  | Required   |
-| --------------------- | -------------------------- | ---------- |
-| `SERVICE_ACCOUNT_KEY` | Firebase SA (base64)       | Yes (prod) |
-| `FIREBASE_DB_URL`     | Firestore URL              | Yes        |
-| `JWT_SECRET`          | JWT signing                | Yes        |
-| `JWT_REFRESH_SECRET`  | Refresh token signing      | Yes        |
-| `PORT`                | Server port (default 3000) | No         |
+Validadas con Zod en `src/config/env.validation.ts`. Acceder siempre via `getEnv()`.
+
+| Variable                  | Propósito                           | Required |
+| ------------------------- | ----------------------------------- | -------- |
+| `SERVICE_ACCOUNT_KEY`     | Firebase SA (base64)                | Yes      |
+| `FIREBASE_DB_URL`         | Firestore URL                       | Yes      |
+| `JWT_SECRET`              | JWT signing                         | Yes      |
+| `JWT_REFRESH_SECRET`      | Refresh token signing               | Yes      |
+| `GOOGLE_CLIENT_ID`        | Google OAuth client ID              | Yes      |
+| `PORT`                    | Server port (default 3000)          | No       |
+| `ALLOWED_ORIGINS`         | CORS origins comma-separated        | No       |
+| `ACCESS_TOKEN_EXPIRES_IN` | Access token TTL (default "15m")    | No       |
+| `REFRESH_TOKEN_EXPIRES_IN`| Refresh token TTL (default "30d")   | No       |
+| `GOOGLE_CLIENT_SECRET`    | Google OAuth client secret          | No       |
+| `CREDENTIALS_JSON`        | Gmail API credentials               | No       |
 
 ---
 
@@ -211,6 +233,9 @@ Before delivering code:
 - [ ] `npm run lint` passes
 - [ ] Entity fields are camelCase
 - [ ] No unnecessary `console.log` (only `console.error` in catches)
+- [ ] POST/PUT routes use `validate(zodSchema)` middleware
+- [ ] Zod schemas defined in `<module>.schemas.ts` with `.strict()`
+- [ ] Environment access via `getEnv()`, never `process.env`
 
 ---
 
@@ -236,15 +261,18 @@ Existing issues to resolve progressively:
 
 ## Key Files
 
-| File                                         | Purpose                      |
-| -------------------------------------------- | ---------------------------- |
-| `src/index.ts`                               | Express app, router mounting |
-| `src/config/firebase.ts`                     | Firebase init, exports `db`  |
-| `src/shared/classes/firestore.repository.ts` | Generic Firestore CRUD       |
-| `src/shared/classes/base.service.ts`         | Generic service CRUD         |
-| `src/shared/middlewares/auth.middleware.ts`  | JWT authentication           |
-| `src/shared/errors/custom.error.ts`          | RepositoryError, AuthError   |
-| `src/shared/utils/date.utils.ts`             | Chile timezone utilities     |
+| File                                            | Purpose                            |
+| ----------------------------------------------- | ---------------------------------- |
+| `src/index.ts`                                  | Express app, router mounting       |
+| `src/config/firebase.ts`                        | Firebase init, exports `db`        |
+| `src/config/env.validation.ts`                  | Zod env schema, `getEnv()`         |
+| `src/shared/classes/firestore.repository.ts`    | Generic Firestore CRUD             |
+| `src/shared/classes/base.service.ts`            | Generic service CRUD               |
+| `src/shared/middlewares/auth.middleware.ts`      | JWT authentication                 |
+| `src/shared/middlewares/validate.middleware.ts`  | Zod req.body validation middleware |
+| `src/shared/services/cache.service.ts`           | In-memory TTL cache + CacheKeys    |
+| `src/shared/errors/custom.error.ts`             | RepositoryError, AuthError         |
+| `src/shared/utils/date.utils.ts`                | Chile timezone utilities           |
 
 ---
 

--- a/skills/myquota-auth/SKILL.md
+++ b/skills/myquota-auth/SKILL.md
@@ -54,6 +54,7 @@ Ubicación: `src/shared/middlewares/auth.middleware.ts`
 ```typescript
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
+import { getEnv } from "@config/env.validation";
 
 export const authenticate = (
   req: Request,
@@ -69,7 +70,7 @@ export const authenticate = (
     }
 
     const token = authHeader.split(" ")[1];
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as {
+    const decoded = jwt.verify(token, getEnv().JWT_SECRET) as {
       userId: string;
     };
 
@@ -117,16 +118,17 @@ Esto permite usar `req.user?.userId` en cualquier parte del código con type saf
 ```typescript
 // En AuthService
 generateTokens(userId: string): { accessToken: string; refreshToken: string } {
+  const env = getEnv();
   const accessToken = jwt.sign(
     { userId },
-    process.env.JWT_SECRET!,
-    { expiresIn: "15m" }
+    env.JWT_SECRET,
+    { expiresIn: env.ACCESS_TOKEN_EXPIRES_IN }
   );
 
   const refreshToken = jwt.sign(
     { userId },
-    process.env.JWT_REFRESH_SECRET!,
-    { expiresIn: "7d" }
+    env.JWT_REFRESH_SECRET,
+    { expiresIn: env.REFRESH_TOKEN_EXPIRES_IN }
   );
 
   return { accessToken, refreshToken };
@@ -150,7 +152,7 @@ refreshToken = async (req: Request, res: Response): Promise<void> => {
 
     const decoded = jwt.verify(
       refreshToken,
-      process.env.JWT_REFRESH_SECRET!,
+      getEnv().JWT_REFRESH_SECRET,
     ) as { userId: string };
 
     const tokens = this.service.generateTokens(decoded.userId);
@@ -165,12 +167,18 @@ refreshToken = async (req: Request, res: Response): Promise<void> => {
 
 ## Variables de Entorno
 
-| Variable             | Propósito                         |
-| -------------------- | --------------------------------- |
-| `JWT_SECRET`         | Secret para firmar access tokens  |
-| `JWT_REFRESH_SECRET` | Secret para firmar refresh tokens |
+Acceder siempre via `getEnv()` de `@config/env.validation`.
+
+| Variable                  | Propósito                                 |
+| ------------------------- | ----------------------------------------- |
+| `JWT_SECRET`              | Secret para firmar access tokens          |
+| `JWT_REFRESH_SECRET`      | Secret para firmar refresh tokens         |
+| `GOOGLE_CLIENT_ID`        | Google OAuth client ID                    |
+| `ACCESS_TOKEN_EXPIRES_IN` | TTL del access token (default "15m")      |
+| `REFRESH_TOKEN_EXPIRES_IN`| TTL del refresh token (default "30d")     |
 
 **Importante**: Usar secrets diferentes para access y refresh tokens.
+**Importante**: NUNCA usar `process.env` directo — siempre `getEnv()`.
 
 ---
 

--- a/skills/myquota-cache/SKILL.md
+++ b/skills/myquota-cache/SKILL.md
@@ -173,9 +173,9 @@ CacheKeys.debtSummary(userId)
 CacheKeys.monthlyStats(userId, creditCardId)
 
 // TTL disponibles
-CacheTTL.SHORT  // 5 min
-CacheTTL.MEDIUM // 15 min
-CacheTTL.LONG   // 30 min
+CacheTTL.SHORT  // 30 seg
+CacheTTL.MEDIUM // 2 min
+CacheTTL.LONG   // 5 min
 
 // Métodos
 CacheService.get<T>(key): T | null

--- a/skills/myquota-controller/SKILL.md
+++ b/skills/myquota-controller/SKILL.md
@@ -165,6 +165,8 @@ getById = async (req: Request, res: Response): Promise<void> => {
 
 ### POST Create
 
+`req.body` llega pre-validado por el middleware `validate(zodSchema)` en las rutas. No es necesario validar estructura en el controller.
+
 ```typescript
 create = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -268,4 +270,5 @@ catch (error) {
 - [ ] Códigos HTTP correctos (200, 201, 404, 500)
 - [ ] Params no usados tienen prefijo `_`
 - [ ] NO hay lógica de negocio en el controller
+- [ ] `req.body` llega pre-validado por Zod (validación se hace en routes)
 - [ ] Respuestas JSON consistentes

--- a/skills/myquota-module/SKILL.md
+++ b/skills/myquota-module/SKILL.md
@@ -24,6 +24,7 @@ Crear módulos completos en MyQuota Backend siguiendo la arquitectura establecid
 ```
 src/modules/<moduleName>/
 ├── <moduleName>.model.ts        # Entidad con IBaseEntity
+├── <moduleName>.schemas.ts      # Zod schemas para validar req.body
 ├── <moduleName>.repository.ts   # Extiende FirestoreRepository<T>
 ├── <moduleName>.service.ts      # Extiende BaseService<T>
 ├── <moduleName>.controller.ts   # Arrow functions con try/catch
@@ -32,8 +33,9 @@ src/modules/<moduleName>/
 
 **Excepciones**:
 
-- Módulos de solo lectura (como `stats`) pueden omitir model y repository
+- Módulos de solo lectura (como `stats`) pueden omitir model, repository y schemas
 - Sub-módulos sin rutas propias pueden omitir controller y routes
+- Módulos complejos pueden tener sub-servicios adicionales (e.g., `emailImport.service.ts`)
 
 ---
 
@@ -245,6 +247,32 @@ export class MyEntityController {
 
 ---
 
+## Template: Schemas (Zod)
+
+```typescript
+// src/modules/<moduleName>/<moduleName>.schemas.ts
+import { z } from "zod";
+
+export const createMyEntitySchema = z
+  .object({
+    name: z.string().min(1),
+    amount: z.number().min(0),
+    isActive: z.boolean().optional(),
+  })
+  .strict();
+
+export const updateMyEntitySchema = createMyEntitySchema.partial();
+```
+
+### Reglas de Schemas
+
+- Usar `.strict()` para rechazar campos extra
+- Schema de update es `.partial()` del create
+- Fechas: `z.string().or(z.coerce.date())` para aceptar ISO strings o Date
+- Un archivo por módulo: `<moduleName>.schemas.ts`
+
+---
+
 ## Template: Routes
 
 ```typescript
@@ -254,6 +282,8 @@ import { MyEntityController } from "./<moduleName>.controller";
 import { MyEntityRepository } from "./<moduleName>.repository";
 import { MyEntityService } from "./<moduleName>.service";
 import { authenticate } from "@shared/middlewares/auth.middleware";
+import { validate } from "@shared/middlewares/validate.middleware";
+import { createMyEntitySchema, updateMyEntitySchema } from "./<moduleName>.schemas";
 
 const createMyEntityRouter = (): Router => {
   const router = Router();
@@ -288,7 +318,7 @@ const createMyEntityRouter = (): Router => {
     return res.locals.myEntityController.getAll(req, res);
   });
 
-  router.post("/myEntities", (req: Request, res: Response) => {
+  router.post("/myEntities", validate(createMyEntitySchema), (req: Request, res: Response) => {
     return res.locals.myEntityController.create(req, res);
   });
 
@@ -296,7 +326,7 @@ const createMyEntityRouter = (): Router => {
     return res.locals.myEntityController.getById(req, res);
   });
 
-  router.put("/myEntities/:itemId", (req: Request, res: Response) => {
+  router.put("/myEntities/:itemId", validate(updateMyEntitySchema), (req: Request, res: Response) => {
     return res.locals.myEntityController.update(req, res);
   });
 
@@ -316,6 +346,7 @@ export default createMyEntityRouter;
 - DI por request: instanciar repo→service→controller en middleware
 - `authenticate` SIEMPRE primero (excepto rutas públicas)
 - Handlers son thin wrappers: `(req, res) => res.locals.controller.method(req, res)`
+- POST/PUT usan `validate(zodSchema)` middleware antes del handler
 
 ---
 
@@ -339,11 +370,14 @@ app.use(errorHandler);
 ## Checklist de Módulo Completo
 
 - [ ] `model.ts` creado con `implements IBaseEntity`
+- [ ] `schemas.ts` creado con Zod schemas (`.strict()`)
 - [ ] `repository.ts` extiende `FirestoreRepository<T>`
 - [ ] `service.ts` extiende `BaseService<T>` y recibe repo por constructor
 - [ ] `controller.ts` usa arrow functions con try/catch
 - [ ] `routes.ts` usa patrón `res.locals` con `authenticate`
+- [ ] POST/PUT usan `validate(zodSchema)` middleware
 - [ ] Router montado en `index.ts`
 - [ ] Imports usan aliases `@shared/`, `@modules/`
 - [ ] Campos de entidad en camelCase
+- [ ] Variables de entorno via `getEnv()`, nunca `process.env`
 - [ ] `npm run lint` pasa

--- a/skills/myquota-repository/SKILL.md
+++ b/skills/myquota-repository/SKILL.md
@@ -158,32 +158,39 @@ async customCreate(data: Partial<MyEntity>): Promise<MyEntity> {
 
 ## Regla de Límites
 
-**Un repositorio gestiona SOLO su colección.** NO acceder a subcolecciones de otras entidades.
+**Un repositorio gestiona SOLO su colección y sus subcolecciones directas.** NO importar ni depender de otros repositorios.
+
+Acceder a subcollections dentro de la jerarquía propia está permitido (e.g., TransactionRepository accediendo a `quotas` que es subcolección de transactions).
 
 ```typescript
-// ❌ INCORRECTO: TransactionRepository accediendo a quotas
+// ❌ INCORRECTO: Repository importando otro repository
+import { CreditCardRepository } from "@modules/creditCard/creditCard.repository";
+
 class TransactionRepository {
-  async getWithQuotas(id: string) {
-    const transaction = await this.findById(id);
-    // NO hacer esto:
-    const quotasRef = this.collection.doc(id).collection("quotas");
+  constructor(
+    userId: string,
+    creditCardId: string,
+    private creditCardRepo: CreditCardRepository, // NO
+  ) { ... }
+}
+
+// ✅ CORRECTO: Acceder a subcollection propia (quotas dentro de transactions)
+class TransactionRepository {
+  getQuotasCollection(transactionId: string) {
+    return this.repository.doc(transactionId).collection("quotas");
   }
 }
 
-// ✅ CORRECTO: Usar QuotaRepository desde el service
+// ✅ CORRECTO: Cross-module access via service (DI)
 class TransactionService {
   constructor(
     private transactionRepo: TransactionRepository,
-    private quotaRepo: QuotaRepository, // Inyectado
+    private creditCardRepo: CreditCardRepository, // Inyectado desde routes
   ) {}
-
-  async getWithQuotas(id: string) {
-    const transaction = await this.transactionRepo.findById(id);
-    const quotas = await this.quotaRepo.findAll();
-    return { ...transaction, quotas };
-  }
 }
 ```
+
+**Regla clave**: Si necesitas datos de otra colección, inyéctalos como dependencia del **service**, no del repository.
 
 ---
 

--- a/skills/myquota-routes/SKILL.md
+++ b/skills/myquota-routes/SKILL.md
@@ -11,6 +11,8 @@ metadata:
     - "Creating routes"
     - "Configuring authentication"
     - "Setting up dependency injection"
+    - "Adding request validation"
+    - "Creating Zod schemas"
 ---
 
 ## Propósito
@@ -27,6 +29,8 @@ import { MyEntityController } from "./myEntity.controller";
 import { MyEntityRepository } from "./myEntity.repository";
 import { MyEntityService } from "./myEntity.service";
 import { authenticate } from "@shared/middlewares/auth.middleware";
+import { validate } from "@shared/middlewares/validate.middleware";
+import { createMyEntitySchema, updateMyEntitySchema } from "./myEntity.schemas";
 
 const createMyEntityRouter = (): Router => {
   const router = Router();
@@ -61,7 +65,7 @@ const createMyEntityRouter = (): Router => {
     return res.locals.myEntityController.getAll(req, res);
   });
 
-  router.post("/myEntities", (req: Request, res: Response) => {
+  router.post("/myEntities", validate(createMyEntitySchema), (req: Request, res: Response) => {
     return res.locals.myEntityController.create(req, res);
   });
 
@@ -69,7 +73,7 @@ const createMyEntityRouter = (): Router => {
     return res.locals.myEntityController.getById(req, res);
   });
 
-  router.put("/myEntities/:itemId", (req: Request, res: Response) => {
+  router.put("/myEntities/:itemId", validate(updateMyEntitySchema), (req: Request, res: Response) => {
     return res.locals.myEntityController.update(req, res);
   });
 
@@ -140,6 +144,11 @@ router.get("/myEntities", (req: Request, res: Response) => {
   return res.locals.myEntityController.getAll(req, res);
 });
 
+// ✅ CORRECTO — POST/PUT con validate middleware
+router.post("/myEntities", validate(createMyEntitySchema), (req: Request, res: Response) => {
+  return res.locals.myEntityController.create(req, res);
+});
+
 // ❌ INCORRECTO — lógica en el handler
 router.get("/myEntities", async (req, res) => {
   try {
@@ -147,6 +156,51 @@ router.get("/myEntities", async (req, res) => {
     res.json(items);
   } catch (err) { ... }
 });
+```
+
+---
+
+## Validación con Zod
+
+Todas las rutas POST/PUT deben usar `validate()` middleware que valida `req.body` contra un Zod schema antes de llegar al controller.
+
+### Definir schemas
+
+```typescript
+// src/modules/<moduleName>/<moduleName>.schemas.ts
+import { z } from "zod";
+
+export const createMyEntitySchema = z
+  .object({
+    name: z.string().min(1),
+    amount: z.number().min(0),
+  })
+  .strict();
+
+export const updateMyEntitySchema = createMyEntitySchema.partial();
+```
+
+### Usar en rutas
+
+```typescript
+import { validate } from "@shared/middlewares/validate.middleware";
+import { createMyEntitySchema, updateMyEntitySchema } from "./myEntity.schemas";
+
+router.post("/myEntities", validate(createMyEntitySchema), (req, res) => {
+  return res.locals.myEntityController.create(req, res);
+});
+
+router.put("/myEntities/:id", validate(updateMyEntitySchema), (req, res) => {
+  return res.locals.myEntityController.update(req, res);
+});
+```
+
+### Reglas de schemas
+
+- Usar `.strict()` para rechazar campos extra
+- Schema de update es `.partial()` del create
+- Fechas: `z.string().or(z.coerce.date())`
+- Un archivo por módulo: `<moduleName>.schemas.ts`
 ```
 
 ---
@@ -268,5 +322,8 @@ const service = new MyEntityService(repository);
 - [ ] Middleware de DI valida userId antes de instanciar
 - [ ] Controller guardado en `res.locals`
 - [ ] Handlers son thin wrappers: `(req, res) => res.locals.controller.method(req, res)`
+- [ ] POST/PUT usan `validate(zodSchema)` middleware
+- [ ] Zod schemas definidos en `<module>.schemas.ts` con `.strict()`
 - [ ] Router montado en `index.ts` con `app.use("/api", ...)`
 - [ ] Rutas anidadas validan todos los IDs necesarios
+- [ ] Variables de entorno via `getEnv()`, nunca `process.env`

--- a/skills/myquota-service/SKILL.md
+++ b/skills/myquota-service/SKILL.md
@@ -193,6 +193,47 @@ export class StatsService {
 
 ---
 
+## Servicios Especializados (Sub-servicios)
+
+Cuando un servicio crece demasiado, extraer concerns específicos a sub-servicios dentro del mismo módulo:
+
+```
+src/modules/transaction/
+├── transaction.service.ts           # Servicio principal (orquesta)
+├── emailImport.service.ts           # Gmail + parsing de emails bancarios
+└── manualTransaction.service.ts     # CRUD de transacciones manuales
+```
+
+### Patrón de Sub-servicio
+
+```typescript
+// src/modules/transaction/emailImport.service.ts
+
+/**
+ * Handles Gmail integration and bank-email parsing.
+ * Extracted from TransactionService to isolate external-API concerns.
+ * Stateless: all dependencies are passed explicitly.
+ */
+export class EmailImportService {
+  async fetchBankEmails(
+    userId: string,
+    creditCardRepository: CreditCardRepository,
+  ): Promise<{ importedCount: number }> {
+    // Lógica específica de importación por email
+  }
+}
+```
+
+### Reglas de Sub-servicios
+
+- **NO extienden BaseService** (no tienen entidad CRUD propia)
+- Reciben dependencias explícitamente (por parámetro o constructor)
+- Son instanciados desde el servicio principal
+- Un archivo separado dentro del mismo módulo
+- Documentar con JSDoc qué concern manejan
+
+---
+
 ## Anti-patterns
 
 ```typescript
@@ -224,3 +265,5 @@ async getAllFormatted(): Promise<string[]> {
 - [ ] Validaciones de entrada en el servicio
 - [ ] Dependencias adicionales inyectadas por constructor
 - [ ] NO instancia repositorios internamente
+- [ ] Variables de entorno via `getEnv()`, nunca `process.env`
+- [ ] Si el servicio crece mucho (≥400 líneas), considerar extraer sub-servicios


### PR DESCRIPTION
## Resumen

Sincroniza la documentacion (AGENTS.md, copilot-instructions.md, y 7 skills) con los patrones actuales del codebase establecidos a lo largo de los PRs #3-#16.

## Cambios por archivo

### AGENTS.md + copilot-instructions.md
- **Tech stack**: agrega Zod 4, helmet, cors, express-rate-limit
- **Project structure**: agrega schemas.ts, shared/services/, validate middleware, sub-servicios
- **Critical rules ALWAYS**: +3 reglas (getEnv, Zod validate, schemas.ts)
- **Critical rules NEVER**: +2 reglas (process.env, req.body sin validar)
- **Environment variables**: tabla completa con todas las vars + nota de getEnv()
- **Key files**: agrega env.validation.ts, validate.middleware.ts, cache.service.ts
- **QA checklist**: agrega items de Zod y getEnv
- **Auto-invoke**: agrega entries de request validation
- **Tech debt**: copilot-instructions.md sincronizado con estado actual (12/13 resueltos)

### Skills actualizados
| Skill | Cambio |
|-------|--------|
| myquota-module | Template schemas.ts, validate() en routes template, checklist ampliado |
| myquota-routes | Seccion Zod validation, validate() middleware pattern, checklist ampliado |
| myquota-auth | process.env -> getEnv(), TTL vars configurables |
| myquota-repository | Regla de limites clarificada (subcollections propias OK, importar otros repos NO) |
| myquota-service | Patron de sub-servicios especializados (EmailImportService, ManualTransactionService) |
| myquota-cache | TTLs corregidos (LONG=5min, MEDIUM=2min, SHORT=30s) |
| myquota-controller | Nota: req.body pre-validado por Zod en routes |