### PR TITLE
chore: add package-lock and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds package-lock.json and .github/dependabot.yml to enable Dependabot for npm and lockfile tracking.