### PR TITLE
fix: correct import path in firestore test

### DIFF
--- a/src/shared/classes/__tests__/firestore.repository.test.ts
+++ b/src/shared/classes/__tests__/firestore.repository.test.ts
@@ -17,7 +17,7 @@ jest.mock('@/config/firebase', () => {
   return { db: { collection: () => mockCollection() } };
 });
 
-import { FirestoreRepository } from './firestore.repository';
+import { FirestoreRepository } from '../firestore.repository';
 
 type Dummy = { id: string; createdAt?: Date | string; updatedAt?: Date | string; deletedAt?: Date | null };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,7 @@
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "src/**/__tests__/**"
   ]
 }


### PR DESCRIPTION
## Summary
- Corregido import en `firestore.repository.test.ts` de `./firestore.repository` a `../firestore.repository`
- Excluidos archivos `__tests__` del build de TypeScript para evitar errores de tipos Jest en producción

## Changes
- `src/shared/classes/__tests__/firestore.repository.test.ts` - fix import path
- `tsconfig.json` - exclude `src/**/__tests__/**`

## Testing
- `npm run build` pasa correctamente