### PR TITLE
feat: what-if projection endpoint

### DIFF
--- a/src/modules/quota/debtForecast.service.ts
+++ b/src/modules/quota/debtForecast.service.ts
@@ -35,43 +35,75 @@ export class DebtForecastService {
     return new Date(year, month - 1, 1).getTime();
   }
 
-  public async getDebtForecast(): Promise<{
+  // Extended Transaction type for what-if simulations
+  public async getDebtForecast(
+    transactionsOverride?: TransactionWithQuotas[],
+  ): Promise<{
     months: MonthBucket[];
     totalDebtCLP: number;
     totalDebtUSD: number;
   }> {
     // --- CACHE ---
     const cacheKey = `debtForecast:${this.userId}`;
-    const cached = CacheService.get<{
-      months: MonthBucket[];
-      totalDebtCLP: number;
-      totalDebtUSD: number;
-    }>(cacheKey);
-    if (cached) return cached;
+    // Do NOT use cached results when a transactionsOverride is provided
+    if (!transactionsOverride || !transactionsOverride.length) {
+      const cached = CacheService.get<{
+        months: MonthBucket[];
+        totalDebtCLP: number;
+        totalDebtUSD: number;
+      }>(cacheKey);
+      if (cached) return cached;
+    }
 
     // --- BATCH FETCH ---
-    // 1. Todas las cuotas pendientes del usuario (collectionGroup)
-    const quotasSnap = await db
-      .collectionGroup("quotas")
-      .where("status", "==", "pending")
-      .where("deletedAt", "==", null)
-      .get();
-    const allQuotas: (Quota & {
-      transactionId: string;
-      creditCardId: string;
-    })[] = quotasSnap.docs.map((doc) => {
-      const data = doc.data() as Quota & { transactionId: string };
-      // Parse creditCardId y transactionId desde el path
-      const path = doc.ref.path.split("/");
-      // ...users/{userId}/creditCards/{creditCardId}/transactions/{transactionId}/quotas/{quotaId}
-      const creditCardId = path[3];
-      const transactionId = path[5];
-      return {
-        ...data,
-        creditCardId,
-        transactionId,
-      };
-    });
+    // If transactionsOverride is provided, use its quotas instead of reading
+    // quotas from Firestore. transactionsOverride is expected to be an array
+    // of Transaction-like objects that MAY include a `quotas` array with
+    // quota objects. This enables temporary, in-memory simulations.
+    let allQuotas: (Quota & { transactionId: string; creditCardId: string })[] = [];
+    const txMap = new Map<string, Transaction>();
+
+    // Temporary type for transaction overrides with quotas
+    interface TransactionWithQuotas extends Transaction {
+      quotas?: Quota[];
+      creditCardId?: string;
+    }
+
+    if (transactionsOverride && transactionsOverride.length) {
+      // Build allQuotas and txMap from the override
+      for (const tx of transactionsOverride) {
+        const txWithQuotas = tx as TransactionWithQuotas;
+        txMap.set(tx.id, tx);
+        const quotasFromTx = txWithQuotas.quotas ?? [];
+        for (const q of quotasFromTx) {
+          allQuotas.push({
+            ...q,
+            transactionId: tx.id,
+            creditCardId: txWithQuotas.creditCardId || "",
+          });
+        }
+      }
+    } else {
+      // 1. Todas las cuotas pendientes del usuario (collectionGroup)
+      const quotasSnap = await db
+        .collectionGroup("quotas")
+        .where("status", "==", "pending")
+        .where("deletedAt", "==", null)
+        .get();
+      allQuotas = quotasSnap.docs.map((doc) => {
+        const data = doc.data() as Quota & { transactionId: string };
+        // Parse creditCardId y transactionId desde el path
+        const path = doc.ref.path.split("/");
+        // ...users/{userId}/creditCards/{creditCardId}/transactions/{transactionId}/quotas/{quotaId}
+        const creditCardId = path[3];
+        const transactionId = path[5];
+        return {
+          ...data,
+          creditCardId,
+          transactionId,
+        };
+      });
+    }
 
     // 2. Todas las tarjetas del usuario
     const cardsSnap = await db
@@ -86,14 +118,14 @@ export class DebtForecastService {
     const cardMap = new Map(cards.map((card) => [card.id, card]));
 
     // 3. Todas las transacciones del usuario (collectionGroup)
-    const txsSnap = await db
-      .collectionGroup("transactions")
-      .where("deletedAt", "==", null)
-      .get();
-    const txs: Transaction[] = txsSnap.docs.map(
-      (doc) => doc.data() as Transaction,
-    );
-    const txMap = new Map(txs.map((tx) => [tx.id, tx]));
+    if (!transactionsOverride || !transactionsOverride.length) {
+      const txsSnap = await db
+        .collectionGroup("transactions")
+        .where("deletedAt", "==", null)
+        .get();
+      const txs: Transaction[] = txsSnap.docs.map((doc) => doc.data() as Transaction);
+      for (const tx of txs) txMap.set(tx.id, tx);
+    }
 
     // 4. Todos los billingPeriods del usuario (collectionGroup)
     const periodsSnap = await db
@@ -228,21 +260,135 @@ export class DebtForecastService {
         periodStartMap.set(p.month, new Date(p.startDate).getTime());
     }
 
-    const sortedBuckets = Array.from(bucketMap.values()).sort((a, b) => {
+    // Build period start map for sorting (used in computeDebtForecast)
+    Array.from(bucketMap.values()).sort((a, b) => {
       const aTime = periodStartMap.get(a.key) ?? this.parseCalendarKey(a.key);
       const bTime = periodStartMap.get(b.key) ?? this.parseCalendarKey(b.key);
       return aTime - bTime;
     });
 
-    const totalDebtCLP = enrichedQuotas
-      .filter((q) => q.currency !== "USD")
-      .reduce((s, q) => s + (q.amount || 0), 0);
-    const totalDebtUSD = enrichedQuotas
-      .filter((q) => q.currency === "USD")
-      .reduce((s, q) => s + (q.amount || 0), 0);
-
-    const result = { months: sortedBuckets, totalDebtCLP, totalDebtUSD };
-    CacheService.set(cacheKey, result, 300); // cache 5 min
+    const result = computeDebtForecast(enrichedQuotas, sortedPeriods);
+    // Only cache real computations (no transactionsOverride)
+    if (!transactionsOverride || !transactionsOverride.length) {
+      CacheService.set(cacheKey, result, 300); // cache 5 min
+    }
     return result;
   }
+}
+
+/**
+ * Pure compute function that turns enriched quotas + billing periods into
+ * month buckets and totals. Exported for reuse and unit testing.
+ */
+export function computeDebtForecast(
+  enrichedQuotas: Array<
+    Quota & {
+      transactionId: string;
+      creditCardId: string;
+      merchant?: string;
+      creditCardLabel?: string;
+      quotaNumber?: number;
+      totalQuotas?: number;
+    }
+  >,
+  sortedPeriods: (BillingPeriod & { creditCardId: string })[],
+): { months: MonthBucket[]; totalDebtCLP: number; totalDebtUSD: number } {
+  // --- AGRUPACIÓN POR MES ---
+  const findPeriodForQuota = (dueDate: string) => {
+    const d = new Date(dueDate).getTime();
+    for (const p of sortedPeriods) {
+      const start = new Date(p.startDate).getTime();
+      const end = new Date(p.endDate).getTime();
+      if (d >= start && d <= end) return p;
+    }
+    return null;
+  };
+
+  const bucketMap = new Map<string, MonthBucket>();
+  for (const q of enrichedQuotas) {
+    // Aseguramos que dueDate es string (puede venir como Date)
+    const dueDateStr =
+      typeof q.dueDate === "string"
+        ? q.dueDate
+        : q.dueDate instanceof Date
+        ? q.dueDate.toISOString()
+        : String(q.dueDate);
+    const period = findPeriodForQuota(dueDateStr);
+    let key: string;
+    let label: string;
+    if (period) {
+      key = period.month;
+      label = period.month;
+    } else {
+      const date = new Date(dueDateStr);
+      key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+      const monthLabel = date.toLocaleDateString("es-CL", {
+        month: "long",
+        year: "numeric",
+        timeZone: "America/Santiago",
+      });
+      label = monthLabel.charAt(0).toUpperCase() + monthLabel.slice(1);
+    }
+    if (!bucketMap.has(key)) {
+      bucketMap.set(key, {
+        key,
+        label,
+        totalCLP: 0,
+        totalUSD: 0,
+        count: 0,
+        details: [],
+        periodsByCard: [],
+      });
+    }
+    const bucket = bucketMap.get(key)!;
+    if (q.currency === "USD") bucket.totalUSD += q.amount;
+    else bucket.totalCLP += q.amount;
+    bucket.count += 1;
+    bucket.details.push({
+      merchant: q.merchant,
+      amount: q.amount,
+      currency: q.currency,
+      quotaNumber: q.quotaNumber!,
+      totalQuotas: q.totalQuotas!,
+      transactionId: q.transactionId,
+      creditCardId: q.creditCardId,
+    });
+  }
+
+  // Populate periodsByCard
+  for (const p of sortedPeriods) {
+    const bucket = bucketMap.get(p.month);
+    if (bucket) {
+      const exists = bucket.periodsByCard.find(
+        (pb) => pb.creditCardId === p.creditCardId && pb.billingPeriodId === p.id,
+      );
+      if (!exists) {
+        bucket.periodsByCard.push({
+          creditCardId: p.creditCardId,
+          billingPeriodId: p.id,
+        });
+      }
+    }
+  }
+
+  const periodStartMap = new Map<string, number>();
+  for (const p of sortedPeriods) {
+    if (!periodStartMap.has(p.month))
+      periodStartMap.set(p.month, new Date(p.startDate).getTime());
+  }
+
+  const sortedBuckets = Array.from(bucketMap.values()).sort((a, b) => {
+    const aTime = periodStartMap.get(a.key) ?? new Date(a.key).getTime();
+    const bTime = periodStartMap.get(b.key) ?? new Date(b.key).getTime();
+    return aTime - bTime;
+  });
+
+  const totalDebtCLP = enrichedQuotas
+    .filter((q) => q.currency !== "USD")
+    .reduce((s, q) => s + (q.amount || 0), 0);
+  const totalDebtUSD = enrichedQuotas
+    .filter((q) => q.currency === "USD")
+    .reduce((s, q) => s + (q.amount || 0), 0);
+
+  return { months: sortedBuckets, totalDebtCLP, totalDebtUSD };
 }

--- a/src/modules/stats/stats.controller.ts
+++ b/src/modules/stats/stats.controller.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
 import { StatsService } from "./stats.service";
+import { WhatIfRequestSchema } from "./stats.schemas";
+import { WhatIfService } from "./stats.service";
 
 export class StatsController {
   constructor(private readonly service: StatsService) {}
@@ -20,6 +22,35 @@ export class StatsController {
     } catch (error) {
       console.error("Error obteniendo estadísticas:", error);
       res.status(500).json({ message: "Error obteniendo estadísticas." });
+    }
+  };
+
+  whatIf = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = WhatIfRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Invalid payload", details: parsed.error.errors });
+        return;
+      }
+
+      const products = parsed.data.products;
+      if (products.length > 50) {
+        res.status(413).json({ error: "Payload too large: max 50 products" });
+        return;
+      }
+
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(400).json({ error: "Missing userId" });
+        return;
+      }
+
+      const service = new WhatIfService(userId);
+      const projection = await service.calculateWhatIf(products);
+      res.status(200).json({ projection, meta: { months: projection.months.length } });
+    } catch (error) {
+      console.error("Error in whatIf endpoint:", error);
+      res.status(500).json({ error: error instanceof Error ? error.message : "Error desconocido" });
     }
   };
 

--- a/src/modules/stats/stats.routes.ts
+++ b/src/modules/stats/stats.routes.ts
@@ -68,6 +68,29 @@ const createStatsRouter = (): Router => {
     },
   );
 
+  // POST /stats/what-if (global per-user endpoint)
+  router.post(
+    "/stats/what-if",
+    authenticate,
+    (req: Request, res: Response) => {
+      // create a lightweight controller here for global endpoint
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(400).json({ message: "Falta userId." });
+        return;
+      }
+      const controller = new (class {
+        async handler(r: Request, s: Response) {
+          // reuse StatsController.whatIf by instantiating a dummy StatsController
+          const StatsControllerClass = require("./stats.controller").StatsController;
+          const c = new StatsControllerClass(null);
+          return c.whatIf(r, s);
+        }
+      })();
+      return controller.handler(req, res);
+    },
+  );
+
   return router;
 };
 

--- a/src/modules/stats/stats.schemas.ts
+++ b/src/modules/stats/stats.schemas.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const WhatIfProductSchema = z.object({
+  merchant: z.string().min(1),
+  amount: z.number().gt(0),
+  currency: z.enum(["CLP", "USD"]),
+  totalInstallments: z.number().int().min(1),
+  firstDueDate: z.string().refine((s) => !isNaN(Date.parse(s)), {
+    message: "Invalid ISO date string",
+  }),
+  creditCardId: z.string().optional(),
+});
+
+export const WhatIfRequestSchema = z.object({
+  products: z.array(WhatIfProductSchema).min(1).max(50),
+});
+
+export const MonthProjectionSchema = z.object({
+  year: z.number().int(),
+  month: z.number().int(),
+  amountCLP: z.number(),
+  amountUSD: z.number(),
+  breakdown: z.any().optional(),
+});
+
+export const WhatIfResponseSchema = z.object({
+  projection: z.array(MonthProjectionSchema),
+  meta: z.object({ months: z.number().int() }),
+});
+
+export type WhatIfProduct = z.infer<typeof WhatIfProductSchema>;
+export type WhatIfRequest = z.infer<typeof WhatIfRequestSchema>;
+export type WhatIfResponse = z.infer<typeof WhatIfResponseSchema>;

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -612,3 +612,60 @@ export class StatsService {
     }
   }
 }
+
+// What-if calculation: map products -> temporary transactions -> call DebtForecastService
+import { WhatIfProduct } from "./stats.schemas";
+import { DebtForecastService } from "@/modules/quota/debtForecast.service";
+
+// Extended Transaction type for what-if simulations
+interface TransactionWithQuotas {
+  id: string;
+  merchant: string;
+  amount: number;
+  currency: string;
+  creditCardId: string;
+  quotas: Array<{
+    id: string;
+    dueDate: string;
+    amount: number;
+    currency: string;
+    status: string;
+  }>;
+}
+
+export class WhatIfService {
+  constructor(private readonly userId: string) {}
+
+  async calculateWhatIf(products: WhatIfProduct[]) {
+    // Map products to temporary transactions with quotas
+    // Each product produces `totalInstallments` quotas starting at firstDueDate
+    const nowBase = Date.now();
+    const transactionsOverride: TransactionWithQuotas[] = products.map((p, idx) => {
+      const txId = `temp-tx-${nowBase}-${idx}`;
+      const quotas: TransactionWithQuotas["quotas"] = [];
+      const first = new Date(p.firstDueDate);
+      for (let i = 0; i < p.totalInstallments; i++) {
+        const due = new Date(first.getFullYear(), first.getMonth() + i, first.getDate());
+        quotas.push({
+          id: `${txId}-q-${i + 1}`,
+          dueDate: due.toISOString(),
+          amount: +(p.amount / p.totalInstallments),
+          currency: p.currency,
+          status: "pending",
+        });
+      }
+      return {
+        id: txId,
+        merchant: p.merchant,
+        amount: p.amount,
+        currency: p.currency,
+        creditCardId: p.creditCardId ?? "",
+        quotas,
+      };
+    });
+
+    const dfs = new DebtForecastService(this.userId);
+    const projection = await dfs.getDebtForecast(transactionsOverride);
+    return projection;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `computeDebtForecast()` function for reusability
- Add `transactionsOverride` param to `getDebtForecast()`
- Add WhatIfProduct Zod schemas
- Add `calculateWhatIf()` service method
- Add POST `/api/stats/what-if` endpoint

## Testing
- Unit tests: `tests/unit/debtForecast.compute.spec.ts`
- Integration tests: `tests/integration/stats.whatif.spec.ts`

## Related
- Frontend PR: cabrerojas/myquota-app#feat/dashboard-glassmorphism-redesign