### PR TITLE
fix: make quota split and regeneration atomic (#44)

### DIFF
--- a/src/modules/quota/__tests__/quota.service.test.ts
+++ b/src/modules/quota/__tests__/quota.service.test.ts
@@ -1,0 +1,74 @@
+import { QuotaService } from "@/modules/quota/quota.service";
+import { QuotaRepository } from "@/modules/quota/quota.repository";
+import { TransactionRepository } from "@/modules/transaction/transaction.repository";
+
+describe("QuotaService.splitTransactionIntoQuotas", () => {
+  const buildService = (transactionRepository: Partial<TransactionRepository>) =>
+    new QuotaService(
+      {} as QuotaRepository,
+      transactionRepository as TransactionRepository,
+    );
+
+  it("replaces quotas atomically in a single repository call", async () => {
+    const findById = jest.fn().mockResolvedValue({
+      id: "tx-1",
+      amount: 1000,
+      currency: "CLP",
+      transactionDate: "2026-01-10T00:00:00.000Z",
+    });
+    const replaceQuotasAtomically = jest.fn().mockResolvedValue({
+      deleted: 2,
+      created: 3,
+    });
+
+    const service = buildService({
+      findById,
+      replaceQuotasAtomically,
+      deleteAllQuotas: jest.fn(),
+      addQuota: jest.fn(),
+      repository: { doc: () => ({ id: "generated-id" }) },
+    } as unknown as TransactionRepository);
+
+    const result = await service.splitTransactionIntoQuotas("cc-1", "tx-1", 3);
+
+    expect(replaceQuotasAtomically).toHaveBeenCalledTimes(1);
+    expect(replaceQuotasAtomically).toHaveBeenCalledWith(
+      "tx-1",
+      expect.arrayContaining([
+        expect.objectContaining({ amount: 333, status: "pending" }),
+        expect.objectContaining({ amount: 334, status: "pending" }),
+      ]),
+    );
+    expect(result.deleted).toBe(2);
+    expect(result.created).toBe(3);
+  });
+
+  it("bubbles up atomic replace failures without fallback writes", async () => {
+    const replaceQuotasAtomically = jest
+      .fn()
+      .mockRejectedValue(new Error("commit failed"));
+    const deleteAllQuotas = jest.fn();
+    const addQuota = jest.fn();
+
+    const service = buildService({
+      findById: jest.fn().mockResolvedValue({
+        id: "tx-1",
+        amount: 500,
+        currency: "CLP",
+        transactionDate: "2026-01-10T00:00:00.000Z",
+      }),
+      replaceQuotasAtomically,
+      deleteAllQuotas,
+      addQuota,
+      repository: { doc: () => ({ id: "generated-id" }) },
+    } as unknown as TransactionRepository);
+
+    await expect(
+      service.splitTransactionIntoQuotas("cc-1", "tx-1", 2),
+    ).rejects.toThrow("commit failed");
+
+    expect(replaceQuotasAtomically).toHaveBeenCalledTimes(1);
+    expect(deleteAllQuotas).not.toHaveBeenCalled();
+    expect(addQuota).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/quota/quota.routes.ts
+++ b/src/modules/quota/quota.routes.ts
@@ -3,7 +3,6 @@ import { QuotaController } from "./quota.controller";
 import { QuotaRepository } from "./quota.repository";
 import { QuotaService } from "./quota.service";
 import { TransactionRepository } from "@/modules/transaction/transaction.repository";
-import { CreditCardRepository } from "@/modules/creditCard/creditCard.repository";
 import { authenticate } from "@/shared/middlewares/auth.middleware";
 import { validate } from "@shared/middlewares/validate.middleware";
 import {
@@ -30,7 +29,6 @@ const createQuotaRouter = (): Router => {
       }
 
       try {
-        const creditCardRepository = new CreditCardRepository(userId);
         const transactionRepository = new TransactionRepository(
           userId,
           creditCardId,
@@ -43,13 +41,14 @@ const createQuotaRouter = (): Router => {
         const service = new QuotaService(
           quotaRepository,
           transactionRepository,
-          creditCardRepository,
         );
         const controller = new QuotaController(service);
         res.locals.quotaController = controller;
         next();
       } catch (error) {
-        console.error("Error en el middleware de Quota:", error);
+        const errorMessage =
+          error instanceof Error ? error.message : "Error desconocido";
+        console.error("Error en el middleware de Quota:", errorMessage);
         res.status(500).json({
           message: "Error interno en la configuración de Quota.",
         });

--- a/src/modules/quota/quota.service.ts
+++ b/src/modules/quota/quota.service.ts
@@ -3,25 +3,18 @@ import { Quota } from "./quota.model";
 import { QuotaRepository } from "./quota.repository";
 
 import { BaseService } from "@/shared/classes/base.service";
+import { RepositoryError } from "@/shared/errors/custom.error";
 import { TransactionRepository } from "@/modules/transaction/transaction.repository";
-import { CreditCardRepository } from "@/modules/creditCard/creditCard.repository";
 
 export class QuotaService extends BaseService<Quota> {
-  // Cambiar el tipo del repository para acceder a los métodos específicos
-  protected repository: QuotaRepository;
   protected transactionRepository: TransactionRepository;
-  protected creditCardRepository: CreditCardRepository;
 
   constructor(
     repository: QuotaRepository,
     transactionRepository: TransactionRepository,
-    creditCardRepository: CreditCardRepository,
   ) {
     super(repository);
-    // Guardar la referencia al repository tipado
-    this.repository = repository;
     this.transactionRepository = transactionRepository;
-    this.creditCardRepository = creditCardRepository;
   }
 
   // Otros métodos específicos del servicio
@@ -39,69 +32,85 @@ export class QuotaService extends BaseService<Quota> {
    * y dueDates mensuales a partir de la fecha de la transacción.
    */
   async splitTransactionIntoQuotas(
-    creditCardId: string,
+    _creditCardId: string,
     transactionId: string,
     numberOfQuotas: number,
   ): Promise<{ deleted: number; created: number; quotas: Quota[] }> {
-    // Validar número de cuotas
-    if (numberOfQuotas < 1 || numberOfQuotas > 48) {
-      throw new Error("El número de cuotas debe estar entre 1 y 48");
+    try {
+      if (numberOfQuotas < 1 || numberOfQuotas > 48) {
+        throw new RepositoryError(
+          "El número de cuotas debe estar entre 1 y 48",
+          400,
+        );
+      }
+
+      const transaction = await this.transactionRepository.findById(transactionId);
+      if (!transaction) {
+        throw new RepositoryError("Transacción no encontrada", 404);
+      }
+
+      const quotas = this.buildSplitQuotas(
+        transaction,
+        transactionId,
+        numberOfQuotas,
+      );
+
+      const { deleted, created } =
+        await this.transactionRepository.replaceQuotasAtomically(
+          transactionId,
+          quotas,
+        );
+
+      return { deleted, created, quotas };
+    } catch (error) {
+      if (error instanceof RepositoryError) {
+        throw error;
+      }
+
+      throw new RepositoryError(
+        error instanceof Error ? error.message : "Error desconocido",
+        500,
+      );
     }
+  }
 
-    // Obtener la transacción
-    const transaction =
-      await this.transactionRepository.findById(transactionId);
-    if (!transaction) {
-      throw new Error("Transacción no encontrada");
-    }
-
-    // Eliminar cuotas existentes
-    const deleted = await this.transactionRepository.deleteAllQuotas(
-      creditCardId,
-      transactionId,
-    );
-
-    // Calcular monto por cuota
-    const cuotaAmount = Math.round(transaction.amount / numberOfQuotas);
+  private buildSplitQuotas(
+    transaction: {
+      amount: number;
+      transactionDate: Date | string;
+      currency: string;
+    },
+    transactionId: string,
+    numberOfQuotas: number,
+  ): Quota[] {
+    const quotaAmount = Math.round(transaction.amount / numberOfQuotas);
     const transactionDate = new Date(transaction.transactionDate);
-
-    // Crear las nuevas cuotas
     const createdQuotas: Quota[] = [];
+
     for (let i = 0; i < numberOfQuotas; i++) {
       const dueDate = new Date(transactionDate);
-      if (numberOfQuotas === 1) {
-        // Pago único: dueDate = fecha de la transacción
-      } else {
-        // Cuotas: primera cuota al mes siguiente, y así sucesivamente
+      if (numberOfQuotas > 1) {
         dueDate.setMonth(dueDate.getMonth() + i + 1);
       }
 
-      // Última cuota absorbe la diferencia del redondeo
       const amount =
         i === numberOfQuotas - 1
-          ? transaction.amount - cuotaAmount * (numberOfQuotas - 1)
-          : cuotaAmount;
+          ? transaction.amount - quotaAmount * (numberOfQuotas - 1)
+          : quotaAmount;
 
-      const quota: Quota = {
+      createdQuotas.push({
         id: this.transactionRepository.repository.doc().id,
         transactionId,
         amount,
-        dueDate: dueDate,
+        dueDate,
         status: "pending",
         currency: transaction.currency,
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
-      };
-
-      await this.transactionRepository.addQuota(
-        creditCardId,
-        transactionId,
-        quota,
-      );
-      createdQuotas.push(quota);
+      });
     }
 
-    return { deleted, created: createdQuotas.length, quotas: createdQuotas };
+    return createdQuotas;
   }
 }

--- a/src/modules/transaction/__tests__/manualTransaction.service.test.ts
+++ b/src/modules/transaction/__tests__/manualTransaction.service.test.ts
@@ -1,0 +1,79 @@
+import { ManualTransactionService } from "@/modules/transaction/manualTransaction.service";
+import { TransactionRepository } from "@/modules/transaction/transaction.repository";
+
+describe("ManualTransactionService.update", () => {
+  const updatePayload = {
+    merchant: "Store",
+    purchaseDate: "2026-01-10T00:00:00.000Z",
+    quotaAmount: 1000,
+    totalInstallments: 3,
+    paidInstallments: 1,
+    lastPaidMonth: "2026-01",
+    currency: "CLP",
+  };
+
+  it("updates transaction and quotas atomically", async () => {
+    const repository = {
+      findById: jest
+        .fn()
+        .mockResolvedValueOnce({ id: "tx-1", source: "manual" })
+        .mockResolvedValueOnce({ id: "tx-1", source: "manual" }),
+      updateTransactionAndReplaceQuotasAtomically: jest
+        .fn()
+        .mockResolvedValue({ deleted: 2, created: 3 }),
+      deleteAllQuotas: jest.fn(),
+      addQuota: jest.fn(),
+      repository: { doc: () => ({ id: `q-${Math.random()}` }) },
+    } as unknown as TransactionRepository;
+
+    const service = new ManualTransactionService(repository);
+
+    const result = await service.update("cc-1", "tx-1", updatePayload);
+
+    expect(
+      repository.updateTransactionAndReplaceQuotasAtomically,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      repository.updateTransactionAndReplaceQuotasAtomically,
+    ).toHaveBeenCalledWith(
+      "tx-1",
+      expect.objectContaining({
+        merchant: "Store",
+        amount: 1000,
+        totalInstallments: 3,
+        paidInstallments: 1,
+      }),
+      expect.arrayContaining([
+        expect.objectContaining({ status: "paid", amount: 1000 }),
+        expect.objectContaining({ status: "pending", amount: 1000 }),
+      ]),
+    );
+    expect(repository.deleteAllQuotas).not.toHaveBeenCalled();
+    expect(repository.addQuota).not.toHaveBeenCalled();
+    expect(result.quotasCreated).toBe(3);
+  });
+
+  it("does not perform partial writes when atomic operation fails", async () => {
+    const repository = {
+      findById: jest.fn().mockResolvedValue({ id: "tx-1", source: "manual" }),
+      updateTransactionAndReplaceQuotasAtomically: jest
+        .fn()
+        .mockRejectedValue(new Error("atomic commit failed")),
+      deleteAllQuotas: jest.fn(),
+      addQuota: jest.fn(),
+      repository: { doc: () => ({ id: "q-id" }) },
+    } as unknown as TransactionRepository;
+
+    const service = new ManualTransactionService(repository);
+
+    await expect(service.update("cc-1", "tx-1", updatePayload)).rejects.toThrow(
+      "atomic commit failed",
+    );
+
+    expect(
+      repository.updateTransactionAndReplaceQuotasAtomically,
+    ).toHaveBeenCalledTimes(1);
+    expect(repository.deleteAllQuotas).not.toHaveBeenCalled();
+    expect(repository.addQuota).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/transaction/manualTransaction.service.ts
+++ b/src/modules/transaction/manualTransaction.service.ts
@@ -1,6 +1,7 @@
 import { TransactionRepository } from "./transaction.repository";
 import { Transaction } from "./transaction.model";
 import { Quota } from "@/modules/quota/quota.model";
+import { RepositoryError } from "@/shared/errors/custom.error";
 
 /**
  * Handles CRUD operations for manual (user-entered) transactions and their
@@ -8,7 +9,7 @@ import { Quota } from "@/modules/quota/quota.model";
  * logic from email-import and reporting concerns.
  */
 export class ManualTransactionService {
-  constructor(private readonly repository: TransactionRepository) {}
+  constructor(protected repository: TransactionRepository) {}
 
   /**
    * Creates a manual transaction with all its quotas (paid and pending).
@@ -86,10 +87,13 @@ export class ManualTransactionService {
   ): Promise<{ deletedQuotas: number }> {
     const transaction = await this.repository.findById(transactionId);
     if (!transaction) {
-      throw new Error("Transacción no encontrada");
+      throw new RepositoryError("Transacción no encontrada", 404);
     }
     if (transaction.source !== "manual") {
-      throw new Error("Solo se pueden eliminar transacciones manuales");
+      throw new RepositoryError(
+        "Solo se pueden eliminar transacciones manuales",
+        400,
+      );
     }
 
     const deletedQuotas = await this.repository.deleteAllQuotas(
@@ -105,7 +109,7 @@ export class ManualTransactionService {
    * Updates a manual transaction: modifies data and recreates all quotas.
    */
   async update(
-    creditCardId: string,
+    _creditCardId: string,
     transactionId: string,
     data: {
       merchant: string;
@@ -120,13 +124,13 @@ export class ManualTransactionService {
   ): Promise<{ transaction: Transaction; quotasCreated: number }> {
     const existing = await this.repository.findById(transactionId);
     if (!existing) {
-      throw new Error("Transacción no encontrada");
+      throw new RepositoryError("Transacción no encontrada", 404);
     }
     if (existing.source !== "manual") {
-      throw new Error("Solo se pueden editar transacciones manuales");
+      throw new RepositoryError("Solo se pueden editar transacciones manuales", 400);
     }
 
-    await this.repository.update(transactionId, {
+    const transactionPatch = {
       merchant: data.merchant,
       amount: data.quotaAmount,
       ...(data.categoryId ? { categoryId: data.categoryId } : {}),
@@ -135,36 +139,57 @@ export class ManualTransactionService {
       totalInstallments: data.totalInstallments,
       paidInstallments: data.paidInstallments,
       updatedAt: new Date(),
-    } as Partial<Transaction>);
+    } as Partial<Transaction>;
 
-    // Delete all existing quotas and recreate them
-    await this.repository.deleteAllQuotas(creditCardId, transactionId);
+    const quotas = this.buildManualQuotas(transactionId, data);
 
+    await this.repository.updateTransactionAndReplaceQuotasAtomically(
+      transactionId,
+      transactionPatch,
+      quotas,
+    );
+
+    const updated = await this.repository.findById(transactionId);
+    if (!updated) {
+      throw new RepositoryError("Transacción no encontrada", 404);
+    }
+
+    return { transaction: updated, quotasCreated: data.totalInstallments };
+  }
+
+  private buildManualQuotas(
+    transactionId: string,
+    data: {
+      quotaAmount: number;
+      totalInstallments: number;
+      paidInstallments: number;
+      lastPaidMonth: string;
+      currency: string;
+    },
+  ): Quota[] {
     const [lastYear, lastMonthNum] = data.lastPaidMonth.split("-").map(Number);
+    const quotas: Quota[] = [];
 
     for (let i = 1; i <= data.totalInstallments; i++) {
       const isPaid = i <= data.paidInstallments;
       const monthOffset = i - data.paidInstallments;
       const dueDate = new Date(lastYear, lastMonthNum - 1 + monthOffset, 15);
 
-      const quota: Quota = {
+      quotas.push({
         id: this.repository.repository.doc().id,
         transactionId,
         amount: data.quotaAmount,
-        dueDate: dueDate,
+        dueDate,
         status: isPaid ? "paid" : "pending",
         currency: data.currency,
         paymentDate: isPaid ? dueDate : null,
         createdAt: new Date(),
         updatedAt: new Date(),
         deletedAt: null,
-      };
-
-      await this.repository.addQuota(creditCardId, transactionId, quota);
+      });
     }
 
-    const updated = await this.repository.findById(transactionId);
-    return { transaction: updated!, quotasCreated: data.totalInstallments };
+    return quotas;
   }
 
   /**

--- a/src/modules/transaction/transaction.repository.ts
+++ b/src/modules/transaction/transaction.repository.ts
@@ -70,6 +70,91 @@ export class TransactionRepository extends FirestoreRepository<Transaction> {
       .set(this.datesToIsoStrings(quota) as Quota);
   }
 
+  async replaceQuotasAtomically(
+    transactionId: string,
+    quotas: Quota[],
+  ): Promise<{ deleted: number; created: number }> {
+    const quotasCollection = this.getQuotasCollection(transactionId);
+    const existingSnapshot = await quotasCollection.get();
+    const batch = this.repository.firestore.batch();
+
+    existingSnapshot.docs.forEach((doc) => {
+      batch.delete(doc.ref);
+    });
+
+    quotas.forEach((quota) => {
+      const quotaId = quota.id || quotasCollection.doc().id;
+      if (!quotaId) {
+        throw new Error("Quota ID inválido para escritura atómica");
+      }
+      const quotaToWrite = {
+        ...quota,
+        id: quotaId,
+      } as Quota;
+
+      batch.set(
+        quotasCollection.doc(quotaId),
+        this.datesToIsoStrings(quotaToWrite) as Quota,
+      );
+    });
+
+    await batch.commit();
+
+    return {
+      deleted: existingSnapshot.size,
+      created: quotas.length,
+    };
+  }
+
+  async updateTransactionAndReplaceQuotasAtomically(
+    transactionId: string,
+    transactionPatch: Partial<Transaction>,
+    quotas: Quota[],
+  ): Promise<{ deleted: number; created: number }> {
+    const transactionRef = this.repository.doc(transactionId);
+    const transactionSnapshot = await transactionRef.get();
+
+    if (!transactionSnapshot.exists) {
+      throw new Error("Transacción no encontrada");
+    }
+
+    const quotasCollection = this.getQuotasCollection(transactionId);
+    const existingSnapshot = await quotasCollection.get();
+    const batch = this.repository.firestore.batch();
+
+    batch.update(
+      transactionRef,
+      this.datesToIsoStrings(transactionPatch as Record<string, unknown>),
+    );
+
+    existingSnapshot.docs.forEach((doc) => {
+      batch.delete(doc.ref);
+    });
+
+    quotas.forEach((quota) => {
+      const quotaId = quota.id || quotasCollection.doc().id;
+      if (!quotaId) {
+        throw new Error("Quota ID inválido para escritura atómica");
+      }
+      const quotaToWrite = {
+        ...quota,
+        id: quotaId,
+      } as Quota;
+
+      batch.set(
+        quotasCollection.doc(quotaId),
+        this.datesToIsoStrings(quotaToWrite) as Quota,
+      );
+    });
+
+    await batch.commit();
+
+    return {
+      deleted: existingSnapshot.size,
+      created: quotas.length,
+    };
+  }
+
   async addQuotaIfAbsent(
     _creditCardId: string,
     transactionId: string,


### PR DESCRIPTION
## Summary
- Reworked quota split to build the full replacement set first and persist it with a single atomic Firestore batch (delete old + create new quotas in one commit).
- Reworked manual transaction quota regeneration to update transaction fields and replace all quotas in one atomic batch operation.
- Added focused tests for split and manual regeneration paths to assert atomic-only write semantics under simulated failures.

## Why
The previous flow executed delete-then-create sequences with multiple writes; a mid-flight error could leave transactions with missing or partially regenerated quotas.

## Scope
- `TransactionRepository`: added atomic helpers `replaceQuotasAtomically` and `updateTransactionAndReplaceQuotasAtomically`.
- `QuotaService`: switched split flow to precompute quotas and call atomic replacement helper.
- `ManualTransactionService`: switched update flow to call atomic transaction+quota replacement helper.
- `Quota routes`: removed unused dependency and aligned middleware error logging pattern.
- Tests: added `quota.service.test.ts` and `manualTransaction.service.test.ts` to cover atomic behavior and failure paths.

## Validation
- `npm test -- src/modules/quota/__tests__/quota.service.test.ts src/modules/transaction/__tests__/manualTransaction.service.test.ts` ✅
- `npm run lint` ✅ (1 pre-existing warning in `src/shared/classes/__tests__/firestore.repository.test.ts`)
- `npm run build` ✅

## Risks
- Batch writes have Firestore operation limits; extremely large quota replacements could require chunking in a future hardening pass.
- Atomicity depends on all replacement writes fitting in a single batch commit.

Closes #44