### PR TITLE
fix: add L1 cache to CreditCardService and BillingPeriodService (#24)

### DIFF
--- a/src/modules/billingPeriod/billingPeriod.service.ts
+++ b/src/modules/billingPeriod/billingPeriod.service.ts
@@ -4,11 +4,17 @@ import { BillingPeriod } from "./billingPeriod.model";
 import { IBaseEntity } from "@/shared/interfaces/base.repository";
 import { toChileStartOfDay, toChileEndOfDay } from "@/shared/utils/date.utils";
 import { TransactionRepository } from "@/modules/transaction/transaction.repository";
+import {
+  CacheService,
+  CacheTTL,
+  CacheKeys,
+} from "@/shared/services/cache.service";
 
 export class BillingPeriodService extends BaseService<BillingPeriod> {
   protected repository: BillingPeriodRepository;
   private transactionRepository: TransactionRepository | null = null;
   private creditCardId: string;
+  private userId?: string;
 
   constructor(
     repository: BillingPeriodRepository,
@@ -21,6 +27,78 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
     if (transactionRepository) {
       this.transactionRepository = transactionRepository;
     }
+    // Extract userId from repository path: ["users", userId, "creditCards", creditCardId]
+    const path = (repository as unknown as { repository: { path: string[] } }).repository?.path;
+    if (path && path.length >= 2) {
+      this.userId = path[1];
+    }
+  }
+
+  /**
+   * Retrieves all billing periods with L1 caching.
+   * Cache TTL: 5 minutes (LONG)
+   */
+  async findAll(): Promise<BillingPeriod[]> {
+    if (!this.userId || !this.creditCardId) {
+      return super.findAll();
+    }
+
+    const cacheKey = CacheKeys.billingPeriods(this.userId, this.creditCardId);
+    const cached = CacheService.get<BillingPeriod[]>(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    const result = await this.repository.findAll();
+    CacheService.set(cacheKey, result, CacheTTL.LONG);
+    return result;
+  }
+
+  /**
+   * Create a billing period and invalidate the cache.
+   */
+  async create(
+    data: Omit<BillingPeriod, keyof IBaseEntity>,
+  ): Promise<BillingPeriod> {
+    const result = await super.create(this.normalizeDates(data));
+    // Invalidate cache after create
+    if (this.userId && this.creditCardId) {
+      CacheService.invalidate(
+        CacheKeys.billingPeriods(this.userId, this.creditCardId),
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Update a billing period and invalidate the cache.
+   */
+  async update(
+    id: string,
+    data: Partial<Omit<BillingPeriod, keyof IBaseEntity>>,
+  ): Promise<BillingPeriod | null> {
+    const result = await super.update(id, this.normalizeDates(data));
+    // Invalidate cache after update
+    if (this.userId && this.creditCardId) {
+      CacheService.invalidate(
+        CacheKeys.billingPeriods(this.userId, this.creditCardId),
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Delete (soft) a billing period and invalidate the cache.
+   */
+  async softDelete(id: string): Promise<boolean> {
+    const result = await super.softDelete(id);
+    // Invalidate cache after delete
+    if (this.userId && this.creditCardId) {
+      CacheService.invalidate(
+        CacheKeys.billingPeriods(this.userId, this.creditCardId),
+      );
+    }
+    return result;
   }
 
   /**
@@ -54,22 +132,8 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
     return normalized;
   }
 
-  async create(
-    data: Omit<BillingPeriod, keyof IBaseEntity>,
-  ): Promise<BillingPeriod> {
-    return super.create(this.normalizeDates(data));
-  }
-
-  async update(
-    id: string,
-    data: Partial<Omit<BillingPeriod, keyof IBaseEntity>>,
-  ): Promise<BillingPeriod | null> {
-    return super.update(id, this.normalizeDates(data));
-  }
-
   /**
-   * Marca como pagadas todas las cuotas pendientes cuyo dueDate
-   * cae dentro del rango del período de facturación.
+   * Mark as paid all pending quotas whose dueDate falls within the billing period range.
    */
   async payBillingPeriod(
     billingPeriodId: string,

--- a/src/modules/creditCard/creditCard.service.ts
+++ b/src/modules/creditCard/creditCard.service.ts
@@ -7,15 +7,79 @@ import {
   CacheKeys,
 } from "@/shared/services/cache.service";
 import { db } from "@/config/firebase";
+import { IBaseEntity } from "@/shared/interfaces/base.repository";
 
 export class CreditCardService extends BaseService<CreditCard> {
   // Cambiar el tipo del repository para acceder a los métodos específicos
   protected repository: CreditCardRepository;
+  private userId?: string;
 
   constructor(repository: CreditCardRepository) {
     super(repository);
     // Guardar la referencia al repository tipado
     this.repository = repository;
+    // Extract userId from repository path: ["users", userId, "creditCards"]
+    const path = (repository as unknown as { repository: { path: string[] } }).repository?.path;
+    if (path && path.length >= 2) {
+      this.userId = path[1];
+    }
+  }
+
+  /**
+   * Retrieves all credit cards for the user with L1 caching.
+   * Cache TTL: 5 minutes (LONG)
+   */
+  async findAll(): Promise<CreditCard[]> {
+    if (!this.userId) {
+      // Fallback: query directly if no userId available
+      return super.findAll();
+    }
+
+    const cacheKey = CacheKeys.creditCards(this.userId);
+    const cached = CacheService.get<CreditCard[]>(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    const result = await this.repository.findAll();
+    CacheService.set(cacheKey, result, CacheTTL.LONG);
+    return result;
+  }
+
+  /**
+   * Create a credit card and invalidate the cache.
+   */
+  async create(data: Omit<CreditCard, keyof IBaseEntity>): Promise<CreditCard> {
+    const result = await super.create(data);
+    // Invalidate cache after create
+    if (this.userId) {
+      CacheService.invalidateByPrefix(CacheKeys.userPrefix(this.userId));
+    }
+    return result;
+  }
+
+  /**
+   * Update a credit card and invalidate the cache.
+   */
+  async update(id: string, data: Partial<Omit<CreditCard, keyof IBaseEntity>>): Promise<CreditCard | null> {
+    const result = await super.update(id, data);
+    // Invalidate cache after update
+    if (this.userId) {
+      CacheService.invalidateByPrefix(CacheKeys.userPrefix(this.userId));
+    }
+    return result;
+  }
+
+  /**
+   * Delete (soft) a credit card and invalidate the cache.
+   */
+  async softDelete(id: string): Promise<boolean> {
+    const result = await super.softDelete(id);
+    // Invalidate cache after delete
+    if (this.userId) {
+      CacheService.invalidateByPrefix(CacheKeys.userPrefix(this.userId));
+    }
+    return result;
   }
 
   /**

--- a/src/shared/services/cache.service.ts
+++ b/src/shared/services/cache.service.ts
@@ -88,6 +88,8 @@ export const CacheKeys = {
   globalCategories: (): string => `global:categories`,
   userCategories: (userId: string): string => `user:${userId}:categories`,
   creditCards: (userId: string): string => `user:${userId}:credit-cards`,
+  billingPeriods: (userId: string, creditCardId: string): string =>
+    `user:${userId}:cc:${creditCardId}:billing-periods`,
   monthlyQuotaSum: (creditCardId: string): string =>
     `cc:${creditCardId}:monthly-quota-sum`,
   userPrefix: (userId: string): string => `user:${userId}:`,


### PR DESCRIPTION
## Summary
- Add L1 memory cache (5-min TTL) to CreditCardService.findAll()
- Add L1 memory cache (5-min TTL) to BillingPeriodService.findAll()
- Add cache invalidation on CRUD operations

## Changes

| File | Change |
|------|--------|
| `creditCard.service.ts` | Added L1 cache with 5-min TTL |
| `billingPeriod.service.ts` | Added L1 cache with 5-min TTL |
| `cache.service.ts` | Added billingPeriods cache key |

## Test Plan
- [ ] Manual: Verify Firebase reads reduced to <500 per session
- [ ] Manual: Navigate app and verify no rate limit errors

Closes #24