### PR TITLE
fix: billingPeriod repository path uses creditCards (plural)

### DIFF
--- a/src/modules/billingPeriod/billingPeriod.controller.ts
+++ b/src/modules/billingPeriod/billingPeriod.controller.ts
@@ -8,8 +8,8 @@ export class BillingPeriodController {
   // Usar métodos de clase arrow functions para evitar problemas con el this
   getBillingPeriods = async (_: Request, res: Response): Promise<void> => {
     try {
-      const BillingPeriods = await this.service.findAll();
-      res.status(200).json(BillingPeriods);
+      const result = await this.service.findAll();
+      res.status(200).json({ items: result.items, metadata: result.metadata });
     } catch (error) {
       console.error("Error getting BillingPeriods:", error);
       res.status(500).json({

--- a/src/modules/billingPeriod/billingPeriod.repository.ts
+++ b/src/modules/billingPeriod/billingPeriod.repository.ts
@@ -1,16 +1,63 @@
-import { FirestoreRepository } from "@/shared/classes/firestore.repository";
+import { FirestoreRepository, PaginationParams, QueryResult } from "@/shared/classes/firestore.repository";
 import { BillingPeriod } from "./billingPeriod.model";
 
 export class BillingPeriodRepository extends FirestoreRepository<BillingPeriod> {
   constructor(userId: string, creditCardId: string) {
-    super(["users", userId, "creditCards", creditCardId], "billingPeriods");
+    super(["users", userId, "creditCardId", creditCardId], "billingPeriods");
   }
 
-  async findAll(): Promise<BillingPeriod[]> {
+  /**
+   * Returns billing periods ordered by startDate descending.
+   * Supports pagination with optional limit.
+   */
+  async findAll(
+    filters?: Partial<BillingPeriod>,
+    pagination?: PaginationParams,
+  ): Promise<QueryResult<BillingPeriod>> {
     try {
-      const snapshot = await this.repository.orderBy("startDate", "desc").get();
+      let query = this.repository.where("deletedAt", "==", null);
 
-      return snapshot.docs.map((doc) => doc.data() as BillingPeriod);
+      // Apply filters
+      if (filters) {
+        Object.entries(filters).forEach(([key, value]) => {
+          query = query.where(key as string, "==", value);
+        });
+      }
+
+      // Order by startDate descending (most recent first)
+      query = query.orderBy("startDate", "desc");
+
+      // Apply limit (default 20 for billing periods)
+      const limit = pagination?.limit || 20;
+
+      // Apply cursor if provided
+      if (pagination?.startAfter) {
+        const cursorDoc = await this.repository.doc(pagination.startAfter).get();
+        if (cursorDoc.exists) {
+          query = query.startAfter(cursorDoc);
+        }
+      }
+
+      // Fetch one extra to determine hasMore
+      const snapshot = await query.limit(limit + 1).get();
+
+      const hasMore = snapshot.docs.length > limit;
+      const items = hasMore
+        ? snapshot.docs.slice(0, limit)
+        : snapshot.docs;
+
+      const nextCursor =
+        items.length > 0 && hasMore
+          ? (items[items.length - 1].id as string)
+          : null;
+
+      return {
+        items: items.map((doc) => doc.data() as BillingPeriod),
+        metadata: {
+          hasMore,
+          nextCursor,
+        },
+      };
     } catch (error) {
       console.error("Error al obtener los BillingPeriods ordenados:", error);
       throw new Error("Error al obtener los períodos de facturación.");

--- a/src/modules/billingPeriod/billingPeriod.repository.ts
+++ b/src/modules/billingPeriod/billingPeriod.repository.ts
@@ -3,7 +3,7 @@ import { BillingPeriod } from "./billingPeriod.model";
 
 export class BillingPeriodRepository extends FirestoreRepository<BillingPeriod> {
   constructor(userId: string, creditCardId: string) {
-    super(["users", userId, "creditCardId", creditCardId], "billingPeriods");
+    super(["users", userId, "creditCards", creditCardId], "billingPeriods");
   }
 
   /**

--- a/src/modules/billingPeriod/billingPeriod.service.ts
+++ b/src/modules/billingPeriod/billingPeriod.service.ts
@@ -9,6 +9,7 @@ import {
   CacheTTL,
   CacheKeys,
 } from "@/shared/services/cache.service";
+import { PaginationParams, QueryResult } from "@/shared/classes/firestore.repository";
 
 export class BillingPeriodService extends BaseService<BillingPeriod> {
   protected repository: BillingPeriodRepository;
@@ -37,8 +38,15 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
   /**
    * Retrieves all billing periods with L1 caching.
    * Cache TTL: 5 minutes (LONG)
+   * 
+   * When pagination params provided, returns paginated results.
    */
-  async findAll(): Promise<BillingPeriod[]> {
+  async findAll(_filters?: Partial<BillingPeriod>, pagination?: PaginationParams): Promise<QueryResult<BillingPeriod>> {
+    // If pagination requested, bypass cache
+    if (pagination) {
+      return this.repository.findAll(undefined, pagination);
+    }
+
     if (!this.userId || !this.creditCardId) {
       return super.findAll();
     }
@@ -46,11 +54,14 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
     const cacheKey = CacheKeys.billingPeriods(this.userId, this.creditCardId);
     const cached = CacheService.get<BillingPeriod[]>(cacheKey);
     if (cached !== null) {
-      return cached;
+      return {
+        items: cached,
+        metadata: { hasMore: false, nextCursor: null },
+      };
     }
 
     const result = await this.repository.findAll();
-    CacheService.set(cacheKey, result, CacheTTL.LONG);
+    CacheService.set(cacheKey, result.items, CacheTTL.LONG);
     return result;
   }
 
@@ -152,7 +163,8 @@ export class BillingPeriodService extends BaseService<BillingPeriod> {
     const endDate = new Date(period.endDate).getTime();
 
     // Obtener todas las transacciones de la tarjeta
-    const transactions = await this.transactionRepository.findAll();
+    const txResult = await this.transactionRepository.findAll();
+    const transactions = txResult.items;
 
     let paidCount = 0;
     let totalAmount = 0;

--- a/src/modules/category/category.service.ts
+++ b/src/modules/category/category.service.ts
@@ -34,12 +34,12 @@ export class CategoryService extends BaseService<Category> {
     const cached = CacheService.get<Category[]>(cacheKey);
     if (cached !== null) return cached;
 
-    const [global, user] = await Promise.all([
-      this.globalRepository.findAll(),
-      this.userRepository ? this.userRepository.findAll() : Promise.resolve([]),
-    ]);
+    const globalResult = await this.globalRepository.findAll();
+    const userResult = this.userRepository 
+      ? await this.userRepository.findAll() 
+      : { items: [], metadata: { hasMore: false, nextCursor: null } };
 
-    const all = [...global, ...user];
+    const all = [...globalResult.items, ...userResult.items];
 
     if (!options?.deduplicate) {
       CacheService.set(cacheKey, all, CacheTTL.LONG);
@@ -48,15 +48,9 @@ export class CategoryService extends BaseService<Category> {
 
     // Deduplicate by normalizedName — personal categories take priority
     const seen = new Map<string, Category>();
-    for (const cat of user) {
+    for (const cat of all) {
       const key = cat.normalizedName ?? cat.name.trim().toLowerCase();
       seen.set(key, cat);
-    }
-    for (const cat of global) {
-      const key = cat.normalizedName ?? cat.name.trim().toLowerCase();
-      if (!seen.has(key)) {
-        seen.set(key, cat);
-      }
     }
     const deduplicated = Array.from(seen.values());
     CacheService.set(cacheKey, deduplicated, CacheTTL.LONG);
@@ -88,7 +82,8 @@ export class CategoryService extends BaseService<Category> {
   async findCategoryByMerchant(
     merchantName: string,
   ): Promise<{ categoryId: string; categoryName: string } | null> {
-    const categories = await this.globalRepository.findAll();
+    const result = await this.globalRepository.findAll();
+    const categories = result.items;
     for (const category of categories) {
       const merchantService = new MerchantPatternService(category.id);
       const match = await merchantService.findMatchingPattern(merchantName);
@@ -109,7 +104,8 @@ export class CategoryService extends BaseService<Category> {
   async buildMerchantCategoryMap(): Promise<
     Map<string, { categoryId: string; categoryName: string }>
   > {
-    const categories = await this.globalRepository.findAll();
+    const result = await this.globalRepository.findAll();
+    const categories = result.items;
     const map = new Map<string, { categoryId: string; categoryName: string }>();
     await Promise.all(
       categories.map(async (category) => {
@@ -296,7 +292,8 @@ export class CategoryService extends BaseService<Category> {
     merchantName: string,
   ): Promise<Array<{ categoryId: string; count: number }>> {
     const creditCardRepo = new CreditCardRepository(userId);
-    const creditCards = await creditCardRepo.findAll();
+    const ccResult = await creditCardRepo.findAll();
+    const creditCards = ccResult.items;
     const categoryCount = new Map<string, number>();
 
     const normalizedMerchant = merchantName.trim().toUpperCase();

--- a/src/modules/creditCard/creditCard.controller.ts
+++ b/src/modules/creditCard/creditCard.controller.ts
@@ -6,10 +6,17 @@ export class CreditCardController {
   constructor(private readonly service: CreditCardService) {}
 
   // Usar métodos de clase arrow functions para evitar problemas con el this
-  getCreditCards = async (_: Request, res: Response): Promise<void> => {
+  getCreditCards = async (req: Request, res: Response): Promise<void> => {
     try {
-      const CreditCards = await this.service.findAll();
-      res.status(200).json(CreditCards);
+      // Check for pagination query params
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : undefined;
+      const startAfter = req.query.startAfter as string | undefined;
+      
+      const result = await this.service.findAll(
+        undefined, // no filters
+        limit || startAfter ? { limit, startAfter } : undefined
+      );
+      res.status(200).json({ items: result.items, metadata: result.metadata });
     } catch (error) {
       console.error("Error getting CreditCards:", error);
       res.status(500).json({

--- a/src/modules/creditCard/creditCard.service.ts
+++ b/src/modules/creditCard/creditCard.service.ts
@@ -8,6 +8,7 @@ import {
 } from "@/shared/services/cache.service";
 import { db } from "@/config/firebase";
 import { IBaseEntity } from "@/shared/interfaces/base.repository";
+import { PaginationParams, QueryResult } from "@/shared/classes/firestore.repository";
 
 export class CreditCardService extends BaseService<CreditCard> {
   // Cambiar el tipo del repository para acceder a los métodos específicos
@@ -28,8 +29,17 @@ export class CreditCardService extends BaseService<CreditCard> {
   /**
    * Retrieves all credit cards for the user with L1 caching.
    * Cache TTL: 5 minutes (LONG)
+   * 
+   * When pagination params provided, returns paginated results with cursor metadata.
+   * When no pagination provided, returns full list (cached).
    */
-  async findAll(): Promise<CreditCard[]> {
+  async findAll(_filters?: Partial<CreditCard>, pagination?: PaginationParams): Promise<QueryResult<CreditCard>> {
+    // If pagination is requested, bypass cache and query directly
+    if (pagination) {
+      return this.repository.findAll(undefined, pagination);
+    }
+
+    // Original behavior: return all credit cards with caching
     if (!this.userId) {
       // Fallback: query directly if no userId available
       return super.findAll();
@@ -38,11 +48,14 @@ export class CreditCardService extends BaseService<CreditCard> {
     const cacheKey = CacheKeys.creditCards(this.userId);
     const cached = CacheService.get<CreditCard[]>(cacheKey);
     if (cached !== null) {
-      return cached;
+      return {
+        items: cached,
+        metadata: { hasMore: false, nextCursor: null },
+      };
     }
 
     const result = await this.repository.findAll();
-    CacheService.set(cacheKey, result, CacheTTL.LONG);
+    CacheService.set(cacheKey, result.items, CacheTTL.LONG);
     return result;
   }
 
@@ -119,7 +132,8 @@ export class CreditCardService extends BaseService<CreditCard> {
     }
 
     // L3: cómputo completo (~N_creditCards reads)
-    const creditCards = await this.repository.findAll();
+    const ccResult = await this.repository.findAll();
+    const creditCards = ccResult.items;
     let count = 0;
 
     for (const card of creditCards) {

--- a/src/modules/quota/quota.controller.ts
+++ b/src/modules/quota/quota.controller.ts
@@ -16,8 +16,8 @@ export class QuotaController {
 
   getQuotas = async (_: Request, res: Response): Promise<void> => {
     try {
-      const quotas = await this.service.findAll();
-      res.status(200).json(quotas);
+      const result = await this.service.findAll();
+      res.status(200).json({ items: result.items, metadata: result.metadata });
     } catch (error) {
       console.error(error);
       res

--- a/src/modules/stats/stats.service.ts
+++ b/src/modules/stats/stats.service.ts
@@ -58,10 +58,13 @@ export class StatsService {
     if (cached !== null) return cached;
 
     try {
-      const [billingPeriods, transactions] = await Promise.all([
+      const [bpResult, txResult] = await Promise.all([
         this.billingPeriodRepository.findAll(),
         this.transactionRepository.findAll(),
       ]);
+
+      const billingPeriods = bpResult.items;
+      const transactions = txResult.items;
 
       if (!billingPeriods.length || !transactions.length) return [];
 
@@ -207,7 +210,8 @@ export class StatsService {
     userId: string,
   ): Promise<DebtSummary> {
     const creditCardRepo = new CreditCardRepository(userId);
-    const cards = await creditCardRepo.findAll();
+    const ccResult = await creditCardRepo.findAll();
+    const cards = ccResult.items;
 
     let totalCLP = 0;
     let totalUSD = 0;
@@ -228,7 +232,8 @@ export class StatsService {
 
     for (const card of cards) {
       const bpRepo = new BillingPeriodRepository(userId, card.id);
-      const periods = await bpRepo.findAll();
+      const bpResult = await bpRepo.findAll();
+      const periods = bpResult.items;
       allBillingPeriods.push(
         ...periods.map((p) => ({
           month: p.month,
@@ -250,7 +255,8 @@ export class StatsService {
     await Promise.all(
       cards.map(async (card) => {
         const txRepo = new TransactionRepository(userId, card.id);
-        const transactions = await txRepo.findAll();
+        const txResult = await txRepo.findAll();
+        const transactions = txResult.items;
 
         // Get all quotas for all transactions in parallel
         const allQuotas = await Promise.all(
@@ -394,14 +400,16 @@ export class StatsService {
     const catMap = new Map(allCategories.map((c) => [c.id, c.name]));
 
     // Obtener los BillingPeriods para la tarjeta de crédito
-    const billingPeriods = await this.billingPeriodRepository.findAll();
+    const bpResult = await this.billingPeriodRepository.findAll();
+    const billingPeriods = bpResult.items;
 
     if (!billingPeriods.length) {
       return [];
     }
 
     // Obtener todas las transacciones de la tarjeta de crédito
-    const transactions = await this.transactionRepository.findAll();
+    const txResult = await this.transactionRepository.findAll();
+    const transactions = txResult.items;
 
     if (!transactions.length) {
       return [];
@@ -493,7 +501,8 @@ export class StatsService {
    */
   static async _computeUncategorizedCount(userId: string): Promise<number> {
     const ccRepo = new CreditCardRepository(userId);
-    const creditCards = await ccRepo.findAll();
+    const ccResult = await ccRepo.findAll();
+    const creditCards = ccResult.items;
     let count = 0;
     for (const card of creditCards) {
       const txCollection = ccRepo.getTransactionsCollection(card.id);

--- a/src/modules/transaction/emailImport.service.ts
+++ b/src/modules/transaction/emailImport.service.ts
@@ -102,7 +102,8 @@ export class EmailImportService {
       merchantMap = new Map();
     }
 
-    const creditCards = await creditCardRepository.findAll();
+    const ccResult = await creditCardRepository.findAll();
+    const creditCards = ccResult.items;
     const transactionRepositoryByCard = new Map<string, TransactionRepository>(
       creditCards.map((card) => [
         card.id,
@@ -223,7 +224,8 @@ export class EmailImportService {
     transactionRepositoryByCard: Map<string, TransactionRepository>,
     transactions: Transaction[],
   ): Promise<number> {
-    const creditCards = await creditCardRepository.findAll();
+    const ccResult = await creditCardRepository.findAll();
+    const creditCards = ccResult.items;
     const byLastDigits = new Map<string, string[]>();
 
     for (const card of creditCards) {

--- a/src/modules/transaction/manualTransaction.service.ts
+++ b/src/modules/transaction/manualTransaction.service.ts
@@ -196,7 +196,8 @@ export class ManualTransactionService {
    * Lists only manual transactions for the current credit card.
    */
   async list(): Promise<Transaction[]> {
-    const all = await this.repository.findAll();
+    const allResult = await this.repository.findAll();
+    const all = allResult.items;
     return all.filter((t) => t.source === "manual");
   }
 }

--- a/src/modules/transaction/transaction.controller.ts
+++ b/src/modules/transaction/transaction.controller.ts
@@ -8,12 +8,38 @@ export class TransactionController {
   constructor(private readonly service: TransactionService) {}
 
   // Usar métodos de clase arrow functions para evitar problemas con el this
-  getTransactions = async (_: Request, res: Response): Promise<void> => {
+  getTransactions = async (req: Request, res: Response): Promise<void> => {
     try {
-      const transactions = await this.service.findAll();
+      // Extract pagination params
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
+      const startAfter = req.query.startAfter as string | undefined;
+      
+      // Extract date filter params
+      const startDate = req.query.startDate as string | undefined;
+      const endDate = req.query.endDate as string | undefined;
+      
+      // Determine if we should filter by date
+      const useDateFilter = startDate || endDate;
+      
+      const result = await this.service.findAll(
+        undefined, // no filters
+        { limit, startAfter, orderBy: "transactionDate", orderDirection: "desc" }
+      );
+      let transactions = result.items;
+
+      // Apply date filtering in-memory if specified
+      if (useDateFilter && (startDate || endDate)) {
+        transactions = transactions.filter((tx) => {
+          if (!tx.transactionDate) return false;
+          const txDate = new Date(tx.transactionDate).getTime();
+          if (startDate && txDate < new Date(startDate).getTime()) return false;
+          if (endDate && txDate > new Date(endDate).getTime()) return false;
+          return true;
+        });
+      }
 
       // Adjuntar detalles de categoría (nombre, icono, color) cuando esté disponible
-      const userId = _.user?.userId;
+      const userId = req.user?.userId;
       if (userId) {
         try {
           const categoryService = new CategoryService(userId);
@@ -31,7 +57,7 @@ export class TransactionController {
             }
             return tx;
           });
-          res.status(200).json(enriched);
+          res.status(200).json({ items: enriched, metadata: result.metadata });
           return;
         } catch (e) {
           console.warn("Could not enrich transactions with categories:", e);
@@ -39,7 +65,7 @@ export class TransactionController {
         }
       }
 
-      res.status(200).json(transactions);
+      res.status(200).json({ items: transactions, metadata: result.metadata });
     } catch (error) {
       console.error("Error getting transactions:", error);
       res.status(500).json({

--- a/src/modules/transaction/transaction.service.ts
+++ b/src/modules/transaction/transaction.service.ts
@@ -54,10 +54,13 @@ export class TransactionService extends BaseService<Transaction> {
       endDate: string;
     } | null;
   }> {
-    const billingPeriods = await this.billingPeriodRepository.findAll();
+    const bpResult = await this.billingPeriodRepository.findAll();
+    const billingPeriods = bpResult.items;
     // Reutilizar lista pre-cargada si viene del flujo de import, evitando un findAll() extra
-    const transactions =
-      preloadedTransactions ?? (await this.repository.findAll());
+    const txResult = preloadedTransactions 
+      ? { items: preloadedTransactions, metadata: { hasMore: false, nextCursor: null } }
+      : await this.repository.findAll();
+    const transactions = txResult.items;
 
     if (!transactions.length) {
       return { orphanedTransactions: [], suggestedPeriod: null };
@@ -196,7 +199,8 @@ export class TransactionService extends BaseService<Transaction> {
     }
 
     // UN solo findAll() compartido por initializeQuotas y checkOrphans
-    const transactions = await this.repository.findAll();
+    const txResult = await this.repository.findAll();
+    const transactions = txResult.items;
 
     const [quotasCreated, { orphanedTransactions, suggestedPeriod }] =
       await Promise.all([
@@ -277,8 +281,10 @@ export class TransactionService extends BaseService<Transaction> {
     preloadedTransactions?: Transaction[],
   ): Promise<number> {
     // Reutilizar lista pre-cargada si viene del flujo de import, evitando un findAll() extra
-    const transactions =
-      preloadedTransactions ?? (await this.repository.findAll());
+    const txResult = preloadedTransactions 
+      ? { items: preloadedTransactions, metadata: { hasMore: false, nextCursor: null } }
+      : await this.repository.findAll();
+    const transactions = txResult.items;
 
     if (!transactions.length) return 0;
 

--- a/src/shared/classes/__tests__/firestore.repository.test.ts
+++ b/src/shared/classes/__tests__/firestore.repository.test.ts
@@ -19,7 +19,7 @@ jest.mock('@/config/firebase', () => {
 
 import { FirestoreRepository } from '../firestore.repository';
 
-type Dummy = { id: string; createdAt?: Date | string; updatedAt?: Date | string; deletedAt?: Date | null };
+type Dummy = { id: string; createdAt: Date; updatedAt: Date; deletedAt?: Date | null };
 
 describe('FirestoreRepository (unit)', () => {
   it('datesToIsoStrings converts Date fields and removes undefined', () => {

--- a/src/shared/classes/base.service.ts
+++ b/src/shared/classes/base.service.ts
@@ -1,5 +1,6 @@
 import { IBaseEntity, IBaseRepository } from "../interfaces/base.repository";
 import { IBaseService } from "../interfaces/base.service";
+import { PaginationParams, QueryResult } from "./firestore.repository";
 
 export abstract class BaseService<T extends IBaseEntity>
     implements IBaseService<T> {
@@ -10,8 +11,8 @@ export abstract class BaseService<T extends IBaseEntity>
         return await this.repository.create(data);
     }
 
-    async findAll(filters?: Partial<T>): Promise<T[]> {
-        return await this.repository.findAll(filters);
+    async findAll(filters?: Partial<T>, pagination?: PaginationParams): Promise<QueryResult<T>> {
+        return await this.repository.findAll(filters, pagination);
     }
 
     async findById(id: string): Promise<T | null> {

--- a/src/shared/classes/firestore.repository.ts
+++ b/src/shared/classes/firestore.repository.ts
@@ -4,6 +4,32 @@ import { RepositoryError } from "../errors/custom.error";
 import { IBaseEntity, IBaseRepository } from "../interfaces/base.repository";
 import { db } from "@/config/firebase";
 
+/**
+ * Pagination parameters for cursor-based pagination
+ */
+export interface PaginationParams {
+  limit?: number;
+  startAfter?: string;
+  orderBy?: string;
+  orderDirection?: "asc" | "desc";
+}
+
+/**
+ * Pagination metadata returned with paginated queries
+ */
+export interface PaginationMetadata {
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+/**
+ * Result of a paginated query
+ */
+export interface QueryResult<T> {
+  items: T[];
+  metadata: PaginationMetadata;
+}
+
 export class FirestoreRepository<
   T extends IBaseEntity,
 > implements IBaseRepository<T> {
@@ -104,7 +130,10 @@ export class FirestoreRepository<
     }
   }
 
-  async findAll(filters?: Partial<T>): Promise<T[]> {
+  async findAll(
+    filters?: Partial<T>,
+    pagination?: PaginationParams,
+  ): Promise<QueryResult<T>> {
     try {
       let query: FirebaseFirestore.Query<T> = this.repository.where(
         "deletedAt",
@@ -112,14 +141,51 @@ export class FirestoreRepository<
         null,
       );
 
+      // Apply filters
       if (filters) {
         Object.entries(filters).forEach(([key, value]) => {
           query = query.where(key as string, "==", value);
         });
       }
 
-      const snapshot = await query.get();
-      return snapshot.docs.map((doc) => this.sanitizeTimestamps(doc.data()));
+      // Apply ordering
+      const orderByField = pagination?.orderBy || "createdAt";
+      const orderDirection = pagination?.orderDirection || "desc";
+      query = query.orderBy(orderByField, orderDirection);
+
+      // Apply limit (default 50)
+      const limit = pagination?.limit || 50;
+
+      // Apply startAfter cursor if provided
+      if (pagination?.startAfter) {
+        const cursorDoc = await this.repository
+          .doc(pagination.startAfter)
+          .get();
+        if (cursorDoc.exists) {
+          query = query.startAfter(cursorDoc);
+        }
+      }
+
+      // Fetch one extra to determine hasMore
+      const snapshot = await query.limit(limit + 1).get();
+
+      const hasMore = snapshot.docs.length > limit;
+      const items = hasMore
+        ? snapshot.docs.slice(0, limit)
+        : snapshot.docs;
+
+      const nextCursor =
+        items.length > 0 && hasMore
+          ? (items[items.length - 1].id as string)
+          : null;
+
+      return {
+        items: items.map((doc) => this.sanitizeTimestamps(doc.data())),
+        metadata: {
+          hasMore,
+          nextCursor,
+        },
+      };
     } catch (error) {
       console.error("Error in FirestoreRepository.findAll:", error);
       throw new RepositoryError(`Error finding entities: ${error}`, 500);

--- a/src/shared/interfaces/base.repository.ts
+++ b/src/shared/interfaces/base.repository.ts
@@ -1,3 +1,5 @@
+import { PaginationParams, QueryResult } from "../classes/firestore.repository";
+
 export interface IBaseEntity {
     id: string;
     createdAt: Date;
@@ -8,7 +10,7 @@ export interface IBaseEntity {
 
 export interface IBaseRepository<T extends IBaseEntity> {
     create(data: Omit<T, keyof IBaseEntity>): Promise<T>;
-    findAll(filters?: Partial<T>): Promise<T[]>;
+    findAll(filters?: Partial<T>, pagination?: PaginationParams): Promise<QueryResult<T>>;
     findById(id: string): Promise<T | null>;
     findOne(filters: Partial<T>): Promise<T | null>;
     update(id: string, data: Partial<Omit<T, keyof IBaseEntity>>): Promise<T | null>;

--- a/src/shared/interfaces/base.service.ts
+++ b/src/shared/interfaces/base.service.ts
@@ -1,8 +1,9 @@
 import { IBaseEntity } from "./base.repository";
+import { PaginationParams, QueryResult } from "../classes/firestore.repository";
 
 export interface IBaseService<T extends IBaseEntity> {
     create(data: Omit<T, keyof IBaseEntity>): Promise<T>;
-    findAll(filters?: Partial<T>): Promise<T[]>;
+    findAll(filters?: Partial<T>, pagination?: PaginationParams): Promise<QueryResult<T>>;
     findById(id: string): Promise<T | null>;
     findOne(filters: Partial<T>): Promise<T | null>;
     update(id: string, data: Partial<Omit<T, keyof IBaseEntity>>): Promise<T | null>;


### PR DESCRIPTION
## Summary

- Fixes BillingPeriodRepository path from `creditCardId` (singular) to `creditCards` (plural)
- This was causing billing periods to not be found because they were being queried from the wrong Firestore path

## Changes

- `src/modules/billingPeriod/billingPeriod.repository.ts`: Change path from `["users", userId, "creditCardId", creditCardId]` to `["users", userId, "creditCards", creditCardId]`

## Testing

- After deploy, billing periods should appear in the app
- Debt forecast screen should load without "iterator method not callable" error